### PR TITLE
Use CI instead of COPILOT_RUNNER environmental variable

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     env:
-      COPILOT_RUNNER: true
+      CI: true
       RAILS_ENV: development
       PGHOST: "127.0.0.1"
       PGPORT: "5432"

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 500
-  <% if ENV["PGHOST"] || ENV["COPILOT_RUNNER"] %>
+  <% if ENV["PGHOST"] || ENV["CI"] %>
   host: <%= ENV["PGHOST"] || "127.0.0.1" %>
   port: <%= ENV["PGPORT"] || 5432 %>
   username: <%= ENV["PGUSER"] || "rails" %>


### PR DESCRIPTION
Copilot was working - but I made one update at the end of #28 without confirming that it worked, and [copilot failed to set up the database again](https://github.com/MayIsBikeMonth/may_is_bike_month/actions/runs/17135334001/job/48609810385).

This was the change:

<img width="1152" height="631" alt="Screenshot 2025-08-21 at 11 35 39 AM" src="https://github.com/user-attachments/assets/71068a7f-93c0-4ecd-a3b8-68b8609d3c24" />

So hopefully, putting the ENV back the way it was will  make things work again.