### PR TITLE
Admin tables use UI::Table component, add dev seed user

### DIFF
--- a/app/views/admin/competition_users/index.html.erb
+++ b/app/views/admin/competition_users/index.html.erb
@@ -16,7 +16,7 @@
   end
 
   table.column(sortable: "created_at") do |cu|
-    tag.span(l(cu.created_at, format: :localize_time), class: "localizeTime")
+    render(UI::Time::Component.new(time: cu.created_at))
   end
 
   if include_competition
@@ -25,7 +25,7 @@
 
   if show_dev_info
     table.column(sortable: "updated_at") do |cu|
-      tag.small(l(cu.updated_at, format: :localize_time), class: "localizeTime")
+      render(UI::Time::Component.new(time: cu.updated_at))
     end
   end
 

--- a/app/views/admin/competition_users/index.html.erb
+++ b/app/views/admin/competition_users/index.html.erb
@@ -5,6 +5,7 @@
 <%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params)) %>
 
 <% include_competition ||= competition_subject.blank? %>
+<%# Local var because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>
 
 <%= render(UI::Table::Component.new(records: @competition_users, render_sortable: true)) do |table|

--- a/app/views/admin/competition_users/index.html.erb
+++ b/app/views/admin/competition_users/index.html.erb
@@ -5,6 +5,7 @@
 <%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params)) %>
 
 <% include_competition ||= competition_subject.blank? %>
+
 <%# Local var because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>
 

--- a/app/views/admin/competition_users/index.html.erb
+++ b/app/views/admin/competition_users/index.html.erb
@@ -4,87 +4,30 @@
 
 <%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params)) %>
 
-<% skip_sortable ||= false %>
 <% include_competition ||= competition_subject.blank? %>
+<% show_dev_info = display_dev_info? %>
 
-<div class="full-screen-table mb-4">
-  <table class="table table-sm table-bordered">
-    <thead class="sortable">
-      <tr>
-        <th>
-          <%= sortable "display_name", skip_sortable: skip_sortable %>
-        </th>
+<%= render(UI::Table::Component.new(records: @competition_users, render_sortable: true)) do |table|
+  table.column(sortable: "display_name") do |cu|
+    safe_join([link_to(cu.display_name, edit_admin_competition_user_path(cu), class: "twlink"),
+      (tag.code(cu.id, class: "only-dev-visible-small") if show_dev_info)].compact)
+  end
 
-        <th>
-          <small>
-            <%= sortable "created_at", skip_sortable: skip_sortable %>
-          </small>
-        </th>
+  table.column(sortable: "created_at") do |cu|
+    tag.span(l(cu.created_at, format: :localize_time), class: "localizeTime")
+  end
 
-        <% if include_competition %>
-          <th>
-            <%= sortable "competition_id", skip_sortable: skip_sortable %>
-          </th>
-        <% end %>
+  if include_competition
+    table.column(sortable: "competition_id") { |cu| cu.competition.display_name }
+  end
 
-        <% if display_dev_info? %>
-          <th>
-            <small>
-              <%= sortable "updated_at", skip_sortable: skip_sortable %>
-            </small>
-          </th>
-        <% end %>
+  if show_dev_info
+    table.column(sortable: "updated_at") do |cu|
+      tag.small(l(cu.updated_at, format: :localize_time), class: "localizeTime")
+    end
+  end
 
-        <th>
-          Activities
-        </th>
+  table.column(label: "Activities") { |cu| number_display(cu.competition_activities.count) }
 
-        <th>Included?</th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% @competition_users.each do |competition_user| %>
-        <tr class="odd:bg-white even:bg-gray-100">
-          <td>
-            <%= link_to competition_user.display_name, edit_admin_competition_user_path(competition_user), class: "twlink" %>
-
-            <% if display_dev_info? %>
-              <code class="only-dev-visible-small">
-                <%= competition_user.id %>
-              </code>
-            <% end %>
-          </td>
-
-          <td>
-            <span class="localizeTime">
-              <%= l(competition_user.created_at, format: :localize_time) %>
-            </span>
-          </td>
-
-          <% if include_competition %>
-            <td>
-              <%= competition_user.competition.display_name %>
-            </td>
-          <% end %>
-
-          <% if display_dev_info? %>
-            <td>
-              <small class="localizeTime">
-                <%= l(competition_user.updated_at, format: :localize_time) %>
-              </small>
-            </td>
-          <% end %>
-
-          <td>
-            <%= number_display(competition_user.competition_activities.count) %>
-          </td>
-
-          <td class="table-cell-check">
-            <%= check_mark if competition_user.included_in_competition %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-</div>
+  table.column(label: "Included?") { |cu| check_mark if cu.included_in_competition }
+end %>

--- a/app/views/admin/competitions/index.html.erb
+++ b/app/views/admin/competitions/index.html.erb
@@ -7,6 +7,7 @@
 
 <%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params)) %>
 
+<%# Local var because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>
 
 <%= render(UI::Table::Component.new(records: @competitions, render_sortable: true)) do |table|

--- a/app/views/admin/competitions/index.html.erb
+++ b/app/views/admin/competitions/index.html.erb
@@ -31,12 +31,12 @@
   table.column(label: "Current?") { |c| check_mark if c.current }
 
   table.column(sortable: "created_at") do |competition|
-    tag.small(l(competition.created_at, format: :localize_time), class: "localizeTime")
+    render(UI::Time::Component.new(time: competition.created_at))
   end
 
   if show_dev_info
     table.column(sortable: "updated_at") do |competition|
-      tag.small(l(competition.updated_at, format: :localize_time), class: "localizeTime")
+      render(UI::Time::Component.new(time: competition.updated_at))
     end
   end
 

--- a/app/views/admin/competitions/index.html.erb
+++ b/app/views/admin/competitions/index.html.erb
@@ -7,99 +7,43 @@
 
 <%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params)) %>
 
-<% skip_sortable ||= false %>
+<% show_dev_info = display_dev_info? %>
 
-<div class="full-screen-table mb-4">
-  <table class="table table-sm table-bordered">
-    <thead class="sortable">
-      <tr>
-        <th>
-          <%= sortable "start_date", skip_sortable: skip_sortable %>
-        </th>
+<%= render(UI::Table::Component.new(records: @competitions, render_sortable: true)) do |table|
+  table.column(sortable: "start_date") do |competition|
+    safe_join([competition.start_date.to_s,
+      (tag.code(competition.id, class: "only-dev-visible-small") if show_dev_info)].compact)
+  end
 
-        <th>
-          <%= sortable "end_date", skip_sortable: skip_sortable %>
-        </th>
+  table.column(sortable: "end_date") do |competition|
+    if competition.start_date.year == competition.end_date.year
+      l competition.end_date, format: :month_date
+    else
+      competition.end_date
+    end
+  end
 
-        <th>
-          <%= sortable "display_name", skip_sortable: skip_sortable %>
-        </th>
+  table.column(sortable: "display_name") do |competition|
+    safe_join([competition.display_name, " ", tag.code(competition.slug, class: "only-dev-visible-small")])
+  end
 
-        <th>Current?</th>
+  table.column(label: "Current?") { |c| check_mark if c.current }
 
-        <th>
-          <small>
-            <%= sortable "created_at", skip_sortable: skip_sortable %>
-          </small>
-        </th>
+  table.column(sortable: "created_at") do |competition|
+    tag.small(l(competition.created_at, format: :localize_time), class: "localizeTime")
+  end
 
-        <% if display_dev_info? %>
-          <th class="only-dev-visible">
-            <small>
-              <%= sortable "updated_at", skip_sortable: skip_sortable %>
-            </small>
-          </th>
-        <% end %>
+  if show_dev_info
+    table.column(sortable: "updated_at") do |competition|
+      tag.small(l(competition.updated_at, format: :localize_time), class: "localizeTime")
+    end
+  end
 
-        <th>Users included</th>
+  table.column(label: "Users included") do |competition|
+    link_to number_display(competition.competition_users_included.count), admin_competition_users_path(search_competition_id: competition.slug), class: "twlink"
+  end
 
-        <th>
-          <small class="text-gray-800">Users excluded</small>
-        </th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% @competitions.each do |competition| %>
-        <tr class="odd:bg-white even:bg-gray-100">
-          <td>
-            <%= competition.start_date %>
-
-            <% if display_dev_info? %>
-              <code class="only-dev-visible-small"><%= competition.id %></code>
-            <% end %>
-          </td>
-
-          <td>
-            <% if competition.start_date.year == competition.end_date.year %>
-              <%= l competition.end_date, format: :month_date %>
-            <% else %>
-              <%= competition.end_date %>
-            <% end %>
-          </td>
-
-          <td>
-            <%= competition.display_name %>
-            <code class="only-dev-visible-small"><%= competition.slug %></code>
-          </td>
-
-          <td class="table-cell-check">
-            <%= check_mark if competition.current %>
-          </td>
-
-          <td>
-            <small class="localizeTime">
-              <%= l(competition.created_at, format: :localize_time) %>
-            </small>
-          </td>
-
-          <% if display_dev_info? %>
-            <td>
-              <small class="localizeTime">
-                <%= l(competition.updated_at, format: :localize_time) %>
-              </small>
-            </td>
-          <% end %>
-
-          <td>
-            <%= link_to number_display(competition.competition_users_included.count), admin_competition_users_path(search_competition_id: competition.slug), class: "twlink" %>
-          </td>
-
-          <td>
-            <%= number_display(competition.competition_users_excluded.count) %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-</div>
+  table.column(label: "Users excluded") do |competition|
+    number_display(competition.competition_users_excluded.count)
+  end
+end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,5 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+User.find_or_create_by!(strava_id: "2430215") do |user|
+  user.role = :developer
+  user.strava_username = "sethherr"
+  user.password = "please12"
+end


### PR DESCRIPTION
## Summary
- Replace raw HTML tables in admin competitions and competition users index views with the `UI::Table::Component`, using its sortable column support
- Add a developer seed user (sethherr, strava_id 2430215) to `db/seeds.rb`

## Test plan
- [x] Admin request specs pass (11 examples, 0 failures)
- [x] Verify admin tables render correctly in browser with sorting
