### PR TITLE
Prevent deploy from being cancelled by newer CI runs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -106,6 +106,9 @@ jobs:
     needs: [lint_and_scan, test]
     runs-on: ubuntu-latest
     environment: production
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The workflow-level `cancel-in-progress: true` was cancelling active production deploys when new commits were pushed to main. This adds a job-level concurrency group on the deploy job with `cancel-in-progress: false`, so deploys queue and complete instead of being interrupted.
