### PR TITLE
Seed 2025 competition data for Seth, Old Scott, and Ali

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Install packages
         run: |
           yarn install --pure-lockfile
+      - name: Test bin/setup
+        run: bin/setup
       - name: build assets
         run: bin/rails assets:precompile
       # Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -97,6 +97,8 @@ jobs:
           yarn install --pure-lockfile
       - name: Test bin/setup
         run: bin/setup
+      - name: Reset database after bin/setup seed
+        run: bin/rails db:schema:load
       - name: build assets
         run: bin/rails assets:precompile
       # Run tests

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "~> 8.1.2"
 gem "pg", "~> 1.6" # Use postgresql as the database for Active Record
 gem "redis" # Redis itself
 gem "sidekiq" # Background job processing (with redis)
+gem "sidekiq-failures" # Failed job tracking in Sidekiq web UI
 
 # Server
 gem "puma" # Use the Puma web server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,6 +505,8 @@ GEM
       logger (>= 1.7.0)
       rack (>= 3.2.0)
       redis-client (>= 0.26.0)
+    sidekiq-failures (1.1.0)
+      sidekiq (>= 4.0.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -645,6 +647,7 @@ DEPENDENCIES
   rspec-retry
   selenium-webdriver
   sidekiq
+  sidekiq-failures
   stackprof
   standard (>= 1.41)
   stimulus-rails

--- a/bin/setup
+++ b/bin/setup
@@ -51,7 +51,7 @@ chdir APP_ROOT do
   system "redis-server &"
 
   puts "\n== Preparing database =="
-  system "bin/rails db:create db:schema:load db:migrate db:seed"
+  system! "bin/rails db:create db:schema:load db:migrate db:seed"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,4 @@
 require "nokogiri"
-require "set"
 
 USERS_2025 = {
   "2430215" => {strava_username: "sethherr", display_name: "seth herr", role: :developer},
@@ -47,7 +46,7 @@ USERS_2025.each do |strava_id, attrs|
 
     timezone = "(GMT-08:00) America/Los_Angeles"
     local_start = date.strftime("%Y-%m-%dT12:00:00Z")
-    utc_start = (Time.utc(date.year, date.month, date.day, 19)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    utc_start = Time.utc(date.year, date.month, date.day, 19).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     strava_data = {
       "id" => activity_strava_id.to_i,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,71 @@
-User.find_or_create_by!(strava_id: "2430215") do |user|
-  user.role = :developer
-  user.strava_username = "sethherr"
-  user.password = "please12"
+require "nokogiri"
+require "set"
+
+USERS_2025 = {
+  "2430215" => {strava_username: "sethherr", display_name: "seth herr", role: :developer},
+  "2557663" => {strava_username: "old_scott", display_name: "Old Scott", role: :basic_user},
+  "7645639" => {strava_username: "ali", display_name: "Ali", role: :basic_user}
+}.freeze
+
+competition = Competition.find_or_create_by!(start_date: Date.new(2025, 5, 1)) do |c|
+  c.end_date = Date.new(2025, 5, 31)
+  c.display_name = "MIBM 2025"
+end
+
+doc = Nokogiri::HTML.fragment(
+  Rails.root.join("app/views/competitions_original/_2025.html.erb").read
+)
+
+USERS_2025.each do |strava_id, attrs|
+  user = User.find_or_create_by!(strava_id:) do |u|
+    u.strava_username = attrs[:strava_username]
+    u.display_name = attrs[:display_name]
+    u.role = attrs[:role]
+  end
+
+  competition_user = CompetitionUser.find_or_create_by!(competition:, user:) do |cu|
+    cu.included_in_competition = true
+  end
+
+  athlete_link = doc.at_css("a[href='https://www.strava.com/athletes/#{strava_id}']")
+  user_row = athlete_link.ancestors("tr").first
+
+  seen = Set.new
+  user_row.css("li").each do |li|
+    activity_link = li.at_css("a[href*='strava.com/activities/']")
+    next unless activity_link
+
+    activity_strava_id = activity_link["href"].split("/").last
+    next unless seen.add?(activity_strava_id)
+
+    name = activity_link.at_css("span").text.strip
+    date_str = li.children.find { |c| c.name == "span" }.text.strip
+    distance_km = li.at_css("span.unit-metric span").text.tr(",", "").to_f
+
+    month, day = date_str.split("-").map(&:to_i)
+    date = Date.new(2025, month, day)
+
+    timezone = "(GMT-08:00) America/Los_Angeles"
+    local_start = date.strftime("%Y-%m-%dT12:00:00Z")
+    utc_start = (Time.utc(date.year, date.month, date.day, 19)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    strava_data = {
+      "id" => activity_strava_id.to_i,
+      "name" => name,
+      "distance" => (distance_km * 1000).round(1),
+      "moving_time" => 1800,
+      "total_elevation_gain" => 50.0,
+      "type" => "Ride",
+      "sport_type" => "Ride",
+      "start_date" => utc_start,
+      "start_date_local" => local_start,
+      "timezone" => timezone,
+      "visibility" => "everyone"
+    }
+
+    activity = competition_user.competition_activities.find_or_initialize_by(strava_id: activity_strava_id)
+    activity.update!(strava_data:)
+  end
+
+  competition_user.update_score_data!
 end


### PR DESCRIPTION
- Replaces the minimal Seth-only seed with a richer dev seed that recreates the MIBM 2025 competition along with three users (seth herr, Old Scott, Ali) and their ride activities.
- Activities are parsed out of `app/views/competitions_original/_2025.html.erb` with Nokogiri so the seed stays in sync with the rendered source. Per-activity moving_time and elevation aren't in the HTML, so synthetic defaults (1800s, 50m) are used while date and distance come from the source.
- Seeds are idempotent via `find_or_create_by`, and \`bin/setup\` already runs `db:seed`.