### PR TITLE
Update binxtils to 0.3.2 and use new shared modules

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.1)
     bindex (0.8.1)
-    binxtils (0.3.0)
+    binxtils (0.3.2)
       activerecord
       activesupport
       functionable
@@ -176,7 +176,7 @@ GEM
     flamegraph (0.9.5)
     foreman (0.88.1)
     formatador (1.1.0)
-    functionable (1.1.0)
+    functionable (1.2.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     groupdate (6.7.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Pagy::Method
   include Binxtils::SetPeriod
+  include Binxtils::ControllerNamespace
 
   self.default_earliest_time = Time.at(1714460400).freeze # 2024-4-30
 
@@ -12,7 +13,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  helper_method :display_dev_info?, :user_root_url, :controller_namespace
+  helper_method :display_dev_info?, :user_root_url
 
   def append_info_to_payload(payload)
     super
@@ -81,10 +82,6 @@ class ApplicationController < ActionController::Base
       flash[:error] = "Not authorized"
       redirect_to user_root_url, status: :see_other
     end
-  end
-
-  def controller_namespace
-    @controller_namespace ||= (self.class.module_parent.name != "Object") ? self.class.module_parent.name.downcase : nil
   end
 
   def store_return_to

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   include Binxtils::SortableHelper
+  include Binxtils::NavHelper
 
   def page_title
     return @page_title if defined?(@page_title)
@@ -46,19 +47,6 @@ module ApplicationHelper
   end
 
   private
-
-  def current_page_active?(link_path, match_controller = false)
-    if match_controller
-      begin
-        link_controller = Rails.application.routes.recognize_path(link_path)[:controller]
-        Rails.application.routes.recognize_path(request.url)[:controller] == link_controller
-      rescue
-        false
-      end
-    else
-      current_page?(link_path)
-    end
-  end
 
   def default_action_name_title
     if action_name == "show"


### PR DESCRIPTION
- Bump binxtils 0.3.0 → 0.3.2 (and pulls functionable 1.1.0 → 1.2.0).
- Replace the local `controller_namespace` method with `Binxtils::ControllerNamespace`.
- Replace the local private `current_page_active?` helper with `Binxtils::NavHelper`.