### PR TITLE
Remove stimulus controller from component generator

### DIFF
--- a/app/components/punchcard/ridge/component.html.erb
+++ b/app/components/punchcard/ridge/component.html.erb
@@ -14,13 +14,8 @@
     Daily total
   </div>
 
-  <div
-    class="
-      max-lg:order-1 max-sm:overflow-x-auto max-sm:px-7 max-sm:-mx-7
-      max-sm:pb-2
-    "
-  >
-    <div class="max-sm:min-w-[480px]">
+  <div class="max-lg:order-1 max-sm:overflow-x-auto max-sm:pb-2 max-sm:-mx-7">
+    <div class="max-sm:min-w-[540px] max-sm:px-7">
       <div class="grid grid-cols-[repeat(31,1fr)] gap-0.5 mb-1 items-end">
         <% bars.each do |bar| %>
           <% if bar[:weekend_label] %>

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -15,7 +15,6 @@ class ComponentGenerator < Rails::Generators::NamedBase
     # Create files in app/components/
     template("component.rb", File.join(app_component_dir, "component.rb"))
     template("component.html.erb", File.join(app_component_dir, "component.html.erb"))
-    template("component_controller.js", stimulus_controller_path)
     template("preview.rb", File.join(app_component_dir, "component_preview.rb"))
 
     # Create tests in spec/components/
@@ -49,14 +48,6 @@ class ComponentGenerator < Rails::Generators::NamedBase
 
   def component_class
     "#{class_name}::Component"
-  end
-
-  def stimulus_controller_path
-    File.join(app_component_dir, "component_controller.js")
-  end
-
-  def stimulus_controller
-    component_class.underscore.split("/").join("--").tr("_", "-")
   end
 
   def app_component_dir

--- a/lib/rails/generators/component/templates/component.html.erb.tt
+++ b/lib/rails/generators/component/templates/component.html.erb.tt
@@ -1,3 +1,3 @@
-<div data-controller="<%= stimulus_controller %>">
+<div>
   <%= component_class %> component
 </div>

--- a/lib/rails/generators/component/templates/component_controller.js.tt
+++ b/lib/rails/generators/component/templates/component_controller.js.tt
@@ -1,9 +1,0 @@
-import { Controller } from '@hotwired/stimulus'
-
-// Connects to data-controller='<%= stimulus_controller %>'
-export default class extends Controller {
-  connect () {
-    console.log('<%= stimulus_controller_path %> - connected to:')
-    console.log(this.element)
-  }
-}


### PR DESCRIPTION
- Drop the `component_controller.js` template and related helpers from the ViewComponent generator so new components no longer ship with a stub Stimulus controller and `data-controller` attribute.
- Tweak the punchcard ridge component's mobile horizontal-scroll wrapper for a cleaner edge offset and slightly wider min-width.