### PR TITLE
Extract styling updates from #91

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -42,6 +42,13 @@
   }
 }
 
+.wrapper-padding {
+  @apply px-4 md:px-7;
+}
+.wrapper-padding-overflow {
+  @apply overflow-x-scroll md:px-7 md:-mx-7 px-4 -mx-4;
+}
+
 @layer components {
   .twlink {
     @apply cursor-pointer underline decoration-1 hover:decoration-2 active:decoration-4 active:text-purple-700 dark:active:text-purple-0 text-purple-500 dark:text-purple-200;
@@ -58,6 +65,37 @@
   }
   .option-inactive {
     @apply opacity-60;
+  }
+
+  .ui-table tbody tr:nth-child(odd) {
+    @apply bg-white dark:bg-purple-900;
+  }
+  .ui-table tbody tr:nth-child(even) {
+    @apply bg-purple-0 dark:bg-purple-800;
+  }
+  .ui-table thead tr th:first-child {
+    @apply rounded-tl-sm;
+  }
+  .ui-table thead tr th:last-child {
+    @apply rounded-tr-sm;
+  }
+  .ui-table tbody tr:last-child td:first-child {
+    @apply rounded-bl-sm;
+  }
+  .ui-table tbody tr:last-child td:last-child {
+    @apply rounded-br-sm;
+  }
+  .ui-table-bordered tbody tr td:first-child {
+    @apply ui-table-bordered-td-first;
+  }
+  .ui-table-bordered tbody tr td:last-child {
+    @apply ui-table-bordered-td-last;
+  }
+  .ui-table-bordered thead tr th:first-child {
+    @apply ui-table-bordered-th-first;
+  }
+  .ui-table-bordered thead tr th:last-child {
+    @apply ui-table-bordered-th-last;
   }
 }
 .twlink.active {
@@ -86,40 +124,6 @@
     font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 focus:outline-none;
 }
 
-@layer components {
-  .ui-table tbody tr:nth-child(odd) {
-    @apply bg-white dark:bg-purple-900;
-  }
-  .ui-table tbody tr:nth-child(even) {
-    @apply bg-purple-0 dark:bg-purple-800;
-  }
-  .ui-table thead tr th:first-child {
-    @apply rounded-tl-sm;
-  }
-  .ui-table thead tr th:last-child {
-    @apply rounded-tr-sm;
-  }
-  .ui-table tbody tr:last-child td:first-child {
-    @apply rounded-bl-sm;
-  }
-  .ui-table tbody tr:last-child td:last-child {
-    @apply rounded-br-sm;
-  }
-
-  .ui-table-bordered tbody tr td:first-child {
-    @apply ui-table-bordered-td-first;
-  }
-  .ui-table-bordered tbody tr td:last-child {
-    @apply ui-table-bordered-td-last;
-  }
-  .ui-table-bordered thead tr th:first-child {
-    @apply ui-table-bordered-th-first;
-  }
-  .ui-table-bordered thead tr th:last-child {
-    @apply ui-table-bordered-th-last;
-  }
-}
-
 /* Side utilities so the borders can be re-applied in JS when columns are hidden */
 @utility ui-table-bordered-td-first {
   @apply border-l border-purple-200 dark:border-purple-700;
@@ -140,9 +144,9 @@
   }
   .punchcard-cell[data-l="1"] { @apply bg-purple-200 dark:bg-purple-900; }
   .punchcard-cell[data-l="2"] { @apply bg-purple-300 dark:bg-purple-800; }
-  .punchcard-cell[data-l="3"] { @apply bg-purple-400 dark:bg-purple-700 shadow-[0_0_6px_rgba(83,46,110,0.45)]; }
-  .punchcard-cell[data-l="4"] { @apply bg-purple-500 dark:bg-purple-600 shadow-[0_0_10px_rgba(110,61,147,0.6)]; }
-  .punchcard-cell[data-l="5"] { @apply bg-purple-600 dark:bg-purple-500 shadow-[0_0_14px_rgba(138,76,184,0.75)]; }
+  .punchcard-cell[data-l="3"] { @apply bg-purple-400 dark:bg-purple-700 shadow-[0_0_5px_rgba(83,46,110,0.3)] dark:shadow-[0_0_6px_rgba(83,46,110,0.45)]; }
+  .punchcard-cell[data-l="4"] { @apply bg-purple-500 dark:bg-purple-600 shadow-[0_0_8px_rgba(110,61,147,0.4)] dark:shadow-[0_0_10px_rgba(110,61,147,0.6)]; }
+  .punchcard-cell[data-l="5"] { @apply bg-purple-600 dark:bg-purple-500 shadow-[0_0_12px_rgba(138,76,184,0.5)] dark:shadow-[0_0_14px_rgba(138,76,184,0.75)]; }
 
   .punchcard-cell:not([data-l])::before,
   .punchcard-cell:not([data-l])::after {
@@ -176,6 +180,30 @@
     }
     .punchcard-week > :first-child {
       grid-column-start: var(--start-col, 4);
+    }
+  }
+
+  [data-punch-activities-for],
+  .punch-activities-container {
+    transition:
+      opacity 250ms ease,
+      transform 250ms ease,
+      display 250ms allow-discrete;
+  }
+  [data-punch-activities-for].hidden\!,
+  .punch-activities-container.hidden\! {
+    opacity: 0;
+    transform: translateY(-4px);
+    transition:
+      opacity 120ms ease,
+      transform 120ms ease,
+      display 120ms allow-discrete;
+  }
+  @starting-style {
+    [data-punch-activities-for]:not(.hidden\!),
+    .punch-activities-container:not(.hidden\!) {
+      opacity: 0;
+      transform: translateY(-4px);
     }
   }
 }

--- a/app/components/navbar/component.html.erb
+++ b/app/components/navbar/component.html.erb
@@ -1,10 +1,10 @@
 <ul
   class="
-    relative flex items-center gap-4 px-2 lg:px-4 justify-end mb-2
-    bg-purple-100 dark:bg-purple-800 rounded-lg py-2
+    relative flex items-center gap-4 wrapper-padding justify-end mb-2
+    bg-purple-100 dark:bg-purple-800 py-2
   "
 >
-  <span class="hidden sm:inline-block ml-2 text-lg font-semibold">
+  <span class="hidden md:inline-block text-lg font-semibold">
     May Is Bike Month Admin
   </span>
 

--- a/app/components/punchcard/body/component.html.erb
+++ b/app/components/punchcard/body/component.html.erb
@@ -8,6 +8,7 @@
 
 <%= render(Punchcard::Rules::Component.new(competition: @competition)) %>
 
+<%# NOTE: must match wrapper-padding for lg screens %>
 <main class="lg:overflow-x-auto lg:-mx-7">
   <div class="lg:min-w-[1340px] lg:px-7">
     <%= render(Punchcard::Ridge::Component.new(daily_totals:)) %>

--- a/app/components/punchcard/header/component.html.erb
+++ b/app/components/punchcard/header/component.html.erb
@@ -16,7 +16,7 @@
   <div
     class="
       grid <%= metric_grid_class %> gap-6 justify-end text-right
-      max-lg:justify-start max-lg:text-left
+      max-lg:justify-start max-lg:text-left max-sm:overflow-x-auto wrapper-padding-overflow
     "
   >
     <% unless competition_over? %>

--- a/app/components/punchcard/ridge/component.html.erb
+++ b/app/components/punchcard/ridge/component.html.erb
@@ -1,6 +1,6 @@
 <div
   class="
-    pt-1 pb-8 grid grid-cols-[220px_1fr_110px] gap-x-3 items-end pb-1.5
+    pt-1 pb-1.5 grid grid-cols-[220px_1fr_110px] gap-x-3 items-end
     max-lg:grid-cols-1 max-lg:gap-x-0
   "
 >
@@ -8,54 +8,61 @@
     class="
       font-mono text-[11px] text-purple-300 dark:text-purple-400 uppercase
       tracking-[0.12em] text-right pr-1 leading-none pb-2
-      max-lg:order-2 max-lg:text-left max-lg:pr-0 max-lg:pt-1.5 max-lg:pb-0
+      max-lg:order-2 max-lg:text-left max-lg:pr-0 max-lg:pt-2
     "
   >
     Daily total
   </div>
 
-  <div class="max-lg:order-1 max-sm:overflow-x-auto max-sm:pb-2 max-sm:-mx-7">
-    <div class="max-sm:min-w-[540px] max-sm:px-7">
-      <div class="grid grid-cols-[repeat(31,1fr)] gap-0.5 mb-1 items-end">
-        <% bars.each do |bar| %>
-          <% if bar[:weekend_label] %>
-            <span
-              class="
-                justify-self-center [writing-mode:vertical-rl] rotate-180
-                font-mono text-[10px] uppercase tracking-[0.1em]
-                text-purple-300 dark:text-purple-400
-              "
-            >
-              <%= bar[:weekend_label] %>
-            </span>
-          <% else %>
-            <span></span>
-          <% end %>
-        <% end %>
-      </div>
-
+  <%# NOTE: must match wrapper-padding for sm screens %>
+  <div class="max-lg:order-1 max-sm:overflow-x-auto max-sm:pb-2 max-sm:-mx-4">
+    <div class="max-sm:min-w-[540px] max-sm:px-4 max-sm:pb-3 max-sm:pt-1">
       <div class="grid grid-cols-[repeat(31,1fr)] gap-0.5 items-end">
         <% bars.each do |bar| %>
-          <%= bar_tag(bar) do %>
-            <span
-              class="<%= bar[:upcoming] ? BAR_EMPTY_CLASS : BAR_GRADIENT_CLASS %>"
-              style="height:<%= "%.1f" % bar[:height_px] %>px"
-              aria-hidden="true"
-            ></span>
+          <div class="flex flex-col items-stretch">
+            <%= bar_tag(bar) do %>
+              <span
+                class="<%= bar[:upcoming] ? BAR_EMPTY_CLASS : BAR_GRADIENT_CLASS %>"
+                style="height:<%= "%.1f" % bar[:height_px] %>px"
+                aria-hidden="true"
+              ></span>
 
-            <span
-              class="
-                block text-center text-purple-300 dark:text-purple-400 font-mono
-                text-[11px] pt-1
-              "
-            >
-              <%= bar[:day] %>
-            </span>
-          <% end %>
+              <span
+                class="
+                  block text-center text-purple-300 dark:text-purple-400
+                  font-mono text-[11px] pt-1
+                "
+              >
+                <%= bar[:day] %>
+              </span>
+
+              <% if bar[:weekend_label] %>
+                <span
+                  class="
+                    self-center [writing-mode:vertical-rl] rotate-180 font-mono
+                    text-[10px] uppercase tracking-[0.1em]
+                    text-purple-300 dark:text-purple-400 mt-0.5
+                  "
+                >
+                  <%= bar[:weekend_label] %>
+                </span>
+              <% end %>
+            <% end %>
+
+            <% unless bar[:weekend_label] %>
+              <span
+                class="
+                  self-center [writing-mode:vertical-rl] rotate-180 font-mono
+                  text-[10px] uppercase tracking-[0.1em] invisible mt-0.5 mb-1
+                "
+                aria-hidden="true"
+              >
+                Sat
+              </span>
+            <% end %>
+          </div>
         <% end %>
       </div>
     </div>
   </div>
-
-  <div></div>
 </div>

--- a/app/components/punchcard/ridge/component.rb
+++ b/app/components/punchcard/ridge/component.rb
@@ -26,12 +26,13 @@ module Punchcard::Ridge
     private
 
     def bar_tag(bar, &)
+      extra_class = " pb-1" if bar[:weekend_label]
       if bar[:upcoming]
-        tag.span(class: SPAN_CLASS, title: bar[:title], &)
+        tag.span(class: "#{SPAN_CLASS}#{extra_class}", title: bar[:title], &)
       else
         tag.button(
           type: "button",
-          class: BUTTON_CLASS,
+          class: "#{BUTTON_CLASS}#{extra_class}",
           title: bar[:title],
           "aria-pressed": "false",
           data: {action: "click->punch#toggleDay", "punch-target": "ridgeBar", date: bar[:date_string]},

--- a/app/components/punchcard/rules/component.html.erb
+++ b/app/components/punchcard/rules/component.html.erb
@@ -1,4 +1,4 @@
-<section class="mb-16 lg:grid lg:grid-cols-[auto_1fr] lg:gap-x-6 lg:items-center">
+<section class="mb-8 lg:mb-16 lg:grid lg:grid-cols-[auto_1fr] lg:gap-x-6 lg:items-center">
   <h4
     class="
       font-mono text-[11px] font-medium uppercase tracking-[0.14em]

--- a/app/components/punchcard/user_activities_for_date/component.html.erb
+++ b/app/components/punchcard/user_activities_for_date/component.html.erb
@@ -1,10 +1,7 @@
 <div
-  class="hidden! inline-flex items-baseline gap-x-1"
+  class="hidden! pl-9 -indent-9 break-inside-avoid pb-1"
   data-punch-activities-for="<%= @punch_id %>"
 >
-  <span class="opacity-50 font-mono text-[11px] shrink-0">
-    <%= short_date %>
-  </span>
-
-  <span><%= activities_html %></span>
+  <span class="opacity-50 font-mono text-[11px]"><%= short_date %></span>
+  <%= activities_html %>
 </div>

--- a/app/components/punchcard/user_row/component.html.erb
+++ b/app/components/punchcard/user_row/component.html.erb
@@ -9,11 +9,11 @@
     <div class="flex items-center gap-2 min-w-0 max-lg:col-start-1 max-lg:row-start-1">
       <span
         class="
-          font-mono text-purple-300 dark:text-purple-400 text-[11px]
-          w-[22px] text-right shrink-0
+          font-mono font-bold text-purple-300 dark:text-purple-400 text-[13px]
+          text-left shrink-0
         "
       >
-        <%= format("%02d", @rank) %>
+        <%= @rank %>
       </span>
 
       <a
@@ -103,7 +103,12 @@
     </div>
   </div>
 
-  <div class="flex flex-wrap gap-x-3 gap-t-2 pb-2 px-2 text-[12px]">
+  <div
+    class="
+      punch-activities-container hidden! columns-1 md:columns-2 lg:columns-3
+      [column-gap:1.5rem] mb-2 text-[12px] mt-2 max-lg:mt-4
+    "
+  >
     <% activities_by_date.each do |date_string, activities| %>
       <%= render(Punchcard::UserActivitiesForDate::Component.new(
         date_string:,

--- a/app/components/punchcard/wrapper/component.html.erb
+++ b/app/components/punchcard/wrapper/component.html.erb
@@ -1,4 +1,7 @@
-<div class="max-w-[1340px] mx-auto pt-8 px-7 pb-20" data-controller="punch">
+<div
+  class="max-w-[1340px] mx-auto pt-8 wrapper-padding pb-20"
+  data-controller="punch"
+>
   <%= render(Punchcard::Body::Component.new(
     competition: @competition,
     competition_users: @competition_users,

--- a/app/components/ui/table/component.html.erb
+++ b/app/components/ui/table/component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="-mx-4 mb-4 overflow-x-scroll px-4 pb-3"
+  class="wrapper-padding-overflow overflow-x-scroll mb-4 pb-3"
   data-controller="ui--table"
   data-ui--table-sticky-value="<%= @sticky %>"
 >

--- a/app/components/user_dropdown/component.html.erb
+++ b/app/components/user_dropdown/component.html.erb
@@ -1,4 +1,4 @@
-<ul class="relative flex items-center gap-4 px-2 lg:px-4 justify-end mt-2 mb-2">
+<ul class="relative flex items-center gap-4 wrapper-padding justify-end mt-2 mb-2">
   <% if !@signed_in %>
     <li>
       <button

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -4,6 +4,6 @@ class CompetitionsController < ApplicationController
     @competition_users = @competition.competition_users_included
       .includes(:user, :competition_activities_included).score_ordered
     @competitions = Competition.start_ordered_desc
-    @page_title = "May is Bike Month #{@competition}"
+    @page_title = @competition.display_name
   end
 end

--- a/app/javascript/controllers/punch_controller.js
+++ b/app/javascript/controllers/punch_controller.js
@@ -111,6 +111,11 @@ export default class extends Controller {
     this.activityEls.forEach(el => {
       el.classList.toggle('hidden!', !activeIds.has(el.dataset.punchActivitiesFor))
     })
+    const containers = new Set(this.activityEls.map(el => el.parentElement))
+    containers.forEach(container => {
+      const anyVisible = Array.from(container.children).some(child => !child.classList.contains('hidden!'))
+      container.classList.toggle('hidden!', !anyVisible)
+    })
   }
 
   syncHideAllButton () {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
       <%= render(UserDropdown::Component.new(current_user:)) %>
     <% end %>
 
-    <div class="<%= "px-4 pb-10 pt-4" if in_admin? %>">
+    <div class="<%= "wrapper-padding pb-10 pt-4" if in_admin? %>">
       <%= yield %>
     </div>
 

--- a/spec/components/punchcard/user_activities_for_date/component_spec.rb
+++ b/spec/components/punchcard/user_activities_for_date/component_spec.rb
@@ -29,11 +29,13 @@ RSpec.describe Punchcard::UserActivitiesForDate::Component, type: :component do
   end
   let(:rendered) { render_inline(component) }
 
-  it "renders a container keyed by punch_id, hidden by default, inline-flex" do
+  it "renders a container keyed by punch_id, hidden by default, with hanging indent" do
     container = rendered.css("[data-punch-activities-for]").first
     expect(container.attr("data-punch-activities-for")).to eq "sam-2025-05-03"
     expect(container.attr("class")).to include "hidden"
-    expect(container.attr("class")).to include "inline-flex"
+    expect(container.attr("class")).to include "pl-9"
+    expect(container.attr("class")).to include "-indent-9"
+    expect(container.attr("class")).to include "break-inside-avoid"
   end
 
   it "shows the short date exactly once" do

--- a/spec/components/punchcard/user_row/component_spec.rb
+++ b/spec/components/punchcard/user_row/component_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Punchcard::UserRow::Component, type: :component do
   end
   let(:rendered) { render_inline(component) }
 
-  it "renders rank zero-padded" do
-    expect(rendered.text).to include "01"
+  it "renders the rank" do
+    expect(rendered.text).to include "1"
   end
 
   it "renders the user display name" do


### PR DESCRIPTION
- Split non-Tooltip changes out of #91 so they can land independently
- Add `wrapper-padding`/`wrapper-padding-overflow` utilities and migrate navbar, user dropdown, wrapper, layout, `ui/table`, and punchcard header to use them
- Restructure ridge weekend labels, tighten rules spacing, switch user-activities to a hanging indent with a columned container that animates open/closed, unpad the user-row rank, scale punchcard-cell glows down in light mode, and set the competition page title from `display_name`