### PR TITLE
Add admin users index page

### DIFF
--- a/app/components/admin/current_header/component.html.erb
+++ b/app/components/admin/current_header/component.html.erb
@@ -36,6 +36,25 @@
     <% end %>
   </p>
 
+  <% if show_user? %>
+    <p class="mb-2">
+      <%= @viewing %> for user:
+      <% if @user_subject.present? %>
+        <strong><%= @user_subject.display_name %></strong>
+      <% else %>
+        <em class="text-rose-600 dark:text-rose-400">
+          User "<%= @user_param %>" missing
+        </em>
+      <% end %>
+      <span class="less-strong">
+        <em>
+          &ndash;
+          <%= link_to "view for all users", url_for(@s_params.merge(user: nil)), class: "twlink" %>
+        </em>
+      </span>
+    </p>
+  <% end %>
+
   <% if render_chart? %>
     <div class="mb-4">
       <%= render(chart_component) %>

--- a/app/components/admin/current_header/component.rb
+++ b/app/components/admin/current_header/component.rb
@@ -3,17 +3,23 @@
 module Admin
   module CurrentHeader
     class Component < ApplicationComponent
-      def initialize(viewing:, searchable_competitions:, s_params:, include_competition_select: false, competition_subject: nil, render_period: false, render_chart: false, chart_collection: nil, time_range: nil, time_range_column: "created_at")
+      def initialize(viewing:, searchable_competitions:, s_params:, include_competition_select: false, competition_subject: nil, user_subject: nil, user_param: nil, render_period: false, render_chart: false, chart_collection: nil, time_range: nil, time_range_column: "created_at")
         @viewing = viewing
         @include_competition_select = include_competition_select
         @s_params = s_params
         @competition_subject = competition_subject
+        @user_subject = user_subject
+        @user_param = user_param
         @searchable_competitions = searchable_competitions
         @render_period = render_period
         @render_chart = render_chart
         @chart_collection = chart_collection
         @time_range = time_range
         @time_range_column = time_range_column
+      end
+
+      def show_user?
+        @user_subject.present? || @user_param.present?
       end
 
       def title

--- a/app/components/navbar/component.html.erb
+++ b/app/components/navbar/component.html.erb
@@ -10,6 +10,7 @@
 
   <%= helpers.active_link "Competition Users", admin_competition_users_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Competitions", admin_competitions_path, class: "twlink ml-2", match_controller: true %>
+  <%= helpers.active_link "Users", admin_users_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Strava Requests", admin_strava_requests_path, class: "twlink ml-2", match_controller: true %>
   <%= link_to "Exit", root_url, class: "twlink ml-auto less-strong" %>
 </ul>

--- a/app/controllers/admin/competition_users_controller.rb
+++ b/app/controllers/admin/competition_users_controller.rb
@@ -33,6 +33,9 @@ class Admin::CompetitionUsersController < Admin::BaseController
     if competition_subject.present?
       competition_users = competition_users.where(competition_id: competition_subject.id)
     end
+    if user_subject.present?
+      competition_users = competition_users.where(user_id: user_subject.id)
+    end
 
     @time_range_column = (sort_column == "updated_at") ? "updated_at" : "created_at"
     competition_users.where(@time_range_column => @time_range)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,21 @@
+class Admin::UsersController < Admin::BaseController
+  include Binxtils::SortableTable
+
+  def index
+    @matching_users = searched_users
+    @users = @matching_users
+      .reorder("users.#{sort_column} #{sort_direction}")
+      .includes(:competition_users)
+  end
+
+  private
+
+  def sortable_columns
+    %w[created_at last_sign_in_at updated_at display_name role sign_in_count]
+  end
+
+  def searched_users
+    @time_range_column = %w[last_sign_in_at updated_at].include?(sort_column) ? sort_column : "created_at"
+    User.where(@time_range_column => @time_range)
+  end
+end

--- a/app/views/admin/competition_users/index.html.erb
+++ b/app/views/admin/competition_users/index.html.erb
@@ -1,4 +1,4 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_competition_users, time_range: @time_range, time_range_column: @time_range_column)) %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_competition_users, time_range: @time_range, time_range_column: @time_range_column)) %>
 
 <% include_competition ||= competition_subject.blank? %>
 

--- a/app/views/admin/strava_requests/index.html.erb
+++ b/app/views/admin/strava_requests/index.html.erb
@@ -1,4 +1,4 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject: nil, searchable_competitions: nil, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_strava_requests, time_range: @time_range)) %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject: nil, user_subject:, user_param: params[:user], searchable_competitions: nil, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_strava_requests, time_range: @time_range)) %>
 
 <%# Local var because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,28 @@
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject: nil, searchable_competitions: nil, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_users, time_range: @time_range, time_range_column: @time_range_column)) %>
+
+<%# Local var because cell blocks run via instance_exec in the table component context %>
+<% show_dev_info = display_dev_info? %>
+
+<%= render(UI::Table::Component.new(records: @users, render_sortable: true)) do |table|
+  table.column(sortable: "display_name", lower_right: (->(u) { u.id } if show_dev_info)) do |user|
+    user.display_name
+  end
+
+  table.column(sortable: "last_sign_in_at", label: "Last sign in") do |user|
+    if user.last_sign_in_at.present?
+      render(UI::Time::Component.new(time: user.last_sign_in_at))
+    end
+  end
+
+  table.column(sortable: "sign_in_count", label: "Sign ins") { |user| number_display(user.sign_in_count) }
+
+  table.column(label: "Competitions") do |user|
+    link_to(number_display(user.competition_users.size), admin_competition_users_path(user: user.slug), class: "twlink")
+  end
+
+  table.column(sortable: "role") { |user| user.role }
+
+  table.column(sortable: "created_at") do |user|
+    render(UI::Time::Component.new(time: user.created_at))
+  end
+end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     resources :competitions, only: %i[index new create]
     resources :competition_users, only: %i[index edit update]
     resources :strava_requests, only: %i[index]
+    resources :users, only: %i[index]
   end
 
   mount Lookbook::Engine, at: "/lookbook" if defined?(Lookbook)

--- a/spec/requests/admin/competition_users_request_spec.rb
+++ b/spec/requests/admin/competition_users_request_spec.rb
@@ -56,6 +56,18 @@ RSpec.describe base_url, type: :request do
           expect(response).to render_template("admin/competition_users/index")
           expect(assigns(:competition_subject).id).to eq competition1.id
           expect(assigns(:competition_users).pluck(:id)).to eq([competition_user1.id])
+
+          get "#{base_url}?user=#{competition_user2.user.slug}"
+          expect(response.code).to eq "200"
+          expect(assigns(:user_subject).id).to eq competition_user2.user_id
+          expect(assigns(:competition_users).pluck(:id)).to eq([competition_user2.id])
+          expect(response.body).to include("for user:")
+          expect(response.body).to include(competition_user2.user.display_name)
+
+          get "#{base_url}?user=unknown-slug"
+          expect(response.code).to eq "200"
+          expect(assigns(:user_subject)).to be_nil
+          expect(response.body).to include(%(User "unknown-slug" missing))
         end
       end
     end

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -23,35 +23,19 @@ RSpec.describe base_url, type: :request do
     include_context :logged_in_as_admin
 
     describe "index" do
-      it "renders" do
-        get base_url
-        expect(response.code).to eq "200"
-        expect(response).to render_template("admin/users/index")
-        expect(assigns(:users).pluck(:id)).to eq([user.id])
-      end
-
-      context "with competition_users" do
-        let!(:competition_user) { FactoryBot.create(:competition_user, user:) }
-
-        it "links to the competition_users filtered by user" do
-          get base_url
-          expect(response.code).to eq "200"
-          expect(response.body).to include(admin_competition_users_path(user: user.slug))
-        end
-      end
-
       context "with multiple users" do
         let!(:older_user) { FactoryBot.create(:user, created_at: Time.current - 2.days, last_sign_in_at: Time.current - 1.hour) }
         let!(:newer_user) { FactoryBot.create(:user, created_at: Time.current - 1.hour, last_sign_in_at: Time.current - 2.days) }
+        let!(:competition_user) { FactoryBot.create(:competition_user, user: newer_user) }
 
-        it "sorts by created_at desc by default" do
+        it "renders, sorts, and links to the user-scoped competition_users" do
           get base_url
           expect(response.code).to eq "200"
+          expect(response).to render_template("admin/users/index")
           ids = assigns(:users).pluck(:id)
           expect(ids.index(newer_user.id)).to be < ids.index(older_user.id)
-        end
+          expect(response.body).to include(admin_competition_users_path(user: newer_user.slug))
 
-        it "sorts by last_sign_in_at" do
           get "#{base_url}?sort=last_sign_in_at&direction=desc"
           expect(response.code).to eq "200"
           expect(assigns(:sort_column)).to eq "last_sign_in_at"

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+base_url = "/admin/users"
+RSpec.describe base_url, type: :request do
+  describe "index" do
+    it "sets return to" do
+      get base_url
+      expect(response).to redirect_to root_url
+      expect(session[:user_return_to]).to eq "/admin/users"
+    end
+
+    context "signed in" do
+      include_context :logged_in_as_user
+      it "flash errors" do
+        get base_url
+        expect(response).to redirect_to root_url
+        expect(flash[:error]).to be_present
+      end
+    end
+  end
+
+  context "signed in as admin" do
+    include_context :logged_in_as_admin
+
+    describe "index" do
+      it "renders" do
+        get base_url
+        expect(response.code).to eq "200"
+        expect(response).to render_template("admin/users/index")
+        expect(assigns(:users).pluck(:id)).to eq([user.id])
+      end
+
+      context "with competition_users" do
+        let!(:competition_user) { FactoryBot.create(:competition_user, user:) }
+
+        it "links to the competition_users filtered by user" do
+          get base_url
+          expect(response.code).to eq "200"
+          expect(response.body).to include(admin_competition_users_path(user: user.slug))
+        end
+      end
+
+      context "with multiple users" do
+        let!(:older_user) { FactoryBot.create(:user, created_at: Time.current - 2.days, last_sign_in_at: Time.current - 1.hour) }
+        let!(:newer_user) { FactoryBot.create(:user, created_at: Time.current - 1.hour, last_sign_in_at: Time.current - 2.days) }
+
+        it "sorts by created_at desc by default" do
+          get base_url
+          expect(response.code).to eq "200"
+          ids = assigns(:users).pluck(:id)
+          expect(ids.index(newer_user.id)).to be < ids.index(older_user.id)
+        end
+
+        it "sorts by last_sign_in_at" do
+          get "#{base_url}?sort=last_sign_in_at&direction=desc"
+          expect(response.code).to eq "200"
+          expect(assigns(:sort_column)).to eq "last_sign_in_at"
+          ids = assigns(:users).pluck(:id)
+          expect(ids.index(older_user.id)).to be < ids.index(newer_user.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/authentication_request_spec.rb
+++ b/spec/requests/authentication_request_spec.rb
@@ -111,6 +111,26 @@ RSpec.describe "Authentication", type: :request do
       expect(user.theme).to eq "theme_system"
     end
 
+    describe "sign-in tracking" do
+      let(:initial_time) { Time.current.change(usec: 0) - 1.day }
+      let(:return_time) { initial_time + 6.hours }
+
+      it "sets last_sign_in_at on initial auth and updates it on subsequent auth" do
+        user = travel_to(initial_time) { signup_and_get_user }
+        expect(user.last_sign_in_at).to match_time(initial_time)
+        expect(user.current_sign_in_at).to match_time(initial_time)
+        expect(user.sign_in_count).to eq 1
+
+        reset!
+        OmniAuth.config.add_mock(:strava, omniauth_data)
+        travel_to(return_time) { post path }
+        user.reload
+        expect(user.last_sign_in_at).to match_time(initial_time)
+        expect(user.current_sign_in_at).to match_time(return_time)
+        expect(user.sign_in_count).to eq 2
+      end
+    end
+
     context "with signup_theme cookie set to dark" do
       it "sets user theme to theme_dark" do
         expect(signup_and_get_user(signup_theme: "dark").theme).to eq "theme_dark"


### PR DESCRIPTION
- Adds sortable `/admin/users` listing with `last_sign_in_at`, sign-in count, role, created_at, display_name, and a Competitions column that links to `admin_competition_users?user=<slug>`
- Extends `Admin::CompetitionUsersController` to filter by `user_subject`, and `Admin::CurrentHeader` to render a "for user: NAME" row (with a missing-user indicator) when a `user` param is passed
- Adds request spec coverage for the new users index, the user-scoped competition_users filter, and Devise trackable behavior through the Strava OAuth callback