### PR TITLE
Hard reload stale tabs after 2 days

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -27,6 +27,20 @@ document.addEventListener('turbo:load', localizeTime)
 document.addEventListener('turbo:render', localizeTime)
 document.addEventListener('turbo:frame-render', localizeTime)
 
+// Hard reload the page if the document has been loaded for more than 2 days,
+// so long-lived tabs pick up asset and markup updates. performance.timeOrigin
+// is set when the HTML document loaded and is not reset by Turbo visits.
+const STALE_DOCUMENT_MS = 2 * 24 * 60 * 60 * 1000
+const reloadIfStale = () => {
+  if (Date.now() - performance.timeOrigin > STALE_DOCUMENT_MS) {
+    window.location.reload()
+  }
+}
+document.addEventListener('turbo:load', reloadIfStale)
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') reloadIfStale()
+})
+
 // const toggleChecks = (event) => {
 //   const checked = event.target.checked
 //   event.target.closest('.toggleChecksWrapper')

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -28,18 +28,14 @@ document.addEventListener('turbo:render', localizeTime)
 document.addEventListener('turbo:frame-render', localizeTime)
 
 // Hard reload the page if the document has been loaded for more than 2 days,
-// so long-lived tabs pick up asset and markup updates. performance.timeOrigin
+// so long-lived idle tabs pick up asset and markup updates. performance.timeOrigin
 // is set when the HTML document loaded and is not reset by Turbo visits.
 const STALE_DOCUMENT_MS = 2 * 24 * 60 * 60 * 1000
-const reloadIfStale = () => {
+setInterval(() => {
   if (Date.now() - performance.timeOrigin > STALE_DOCUMENT_MS) {
     window.location.reload()
   }
-}
-document.addEventListener('turbo:load', reloadIfStale)
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') reloadIfStale()
-})
+}, 60 * 60 * 1000)
 
 // const toggleChecks = (event) => {
 //   const checked = event.target.checked


### PR DESCRIPTION
## Summary
- Adds an hourly `setInterval` in `app/javascript/application.js` that compares `Date.now()` to `performance.timeOrigin` and calls `window.location.reload()` when the document has been loaded for more than 2 days.
- Goal: long-lived idle tabs pick up asset and markup updates without a manual refresh, even if they never receive a `turbo:load` or become backgrounded.

## Test plan
- [ ] Open a page, confirm no reload occurs during normal use.
- [ ] Temporarily shorten `STALE_DOCUMENT_MS` and the interval locally, and verify the page hard-reloads once the threshold is exceeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)