### PR TITLE
Punchcard cleanup: tooltip counts, dup-year disambiguation, empty-day selection

### DIFF
--- a/app/components/other_competition_links/component.html.erb
+++ b/app/components/other_competition_links/component.html.erb
@@ -2,12 +2,21 @@
   <p class="text-base">
     View results from:
     <%= safe_join(@competitions.map { |competition|
-      if current_competition?(competition)
-        tag.span(competition.year, class: "opacity-50", title: CURRENT_TITLE)
-      elsif @original_view
-        link_to(competition.year, competitions_original_path(competition.year), class: "twlink")
+      label = if show_display_name?(competition)
+        safe_join([
+          competition.year.to_s,
+          tag.span(" (#{competition.display_name})", class: "text-xs font-normal")
+        ])
       else
-        link_to(competition.year, competition_path(competition.slug), class: "twlink")
+        competition.year.to_s
+      end
+
+      if current_competition?(competition)
+        tag.span(label, class: "opacity-50", title: CURRENT_TITLE)
+      elsif @original_view
+        link_to(label, competitions_original_path(competition.year), class: "twlink")
+      else
+        link_to(label, competition_path(competition.slug), class: "twlink")
       end
     }, ", ") %>
   </p>

--- a/app/components/other_competition_links/component.rb
+++ b/app/components/other_competition_links/component.rb
@@ -4,16 +4,24 @@ module OtherCompetitionLinks
   class Component < ApplicationComponent
     CURRENT_TITLE = "You're looking at it"
 
-    def initialize(competitions:, current_year:, original_view: false)
+    def initialize(competitions:, current_competition:, original_view: false)
       @competitions = competitions
-      @current_year = current_year
+      @current_competition = current_competition
       @original_view = original_view
     end
 
     private
 
     def current_competition?(competition)
-      competition.year == @current_year
+      @current_competition == competition
+    end
+
+    def show_display_name?(competition)
+      multi_entry_years.include?(competition.year)
+    end
+
+    def multi_entry_years
+      @multi_entry_years ||= @competitions.group_by(&:year).select { |_, cs| cs.size > 1 }.keys
     end
   end
 end

--- a/app/components/other_competition_links/component_preview.rb
+++ b/app/components/other_competition_links/component_preview.rb
@@ -3,17 +3,32 @@
 module OtherCompetitionLinks
   class ComponentPreview < ApplicationComponentPreview
     def default
+      competitions = sample_competitions
       render(OtherCompetitionLinks::Component.new(
-        competitions: sample_competitions,
-        current_year: 2025
+        competitions:,
+        current_competition: competitions.find { |c| c.year == 2025 }
       ))
     end
 
     def original_view
+      competitions = sample_competitions
       render(OtherCompetitionLinks::Component.new(
-        competitions: sample_competitions,
-        current_year: 2024,
+        competitions:,
+        current_competition: competitions.find { |c| c.year == 2024 },
         original_view: true
+      ))
+    end
+
+    def multiple_per_year
+      competitions = [
+        Competition.new(start_date: Date.new(2026, 5, 1), display_name: "MIBM 2026"),
+        Competition.new(start_date: Date.new(2025, 5, 1), display_name: "MIBM Spring 2025"),
+        Competition.new(start_date: Date.new(2025, 5, 1), display_name: "MIBM Fall 2025"),
+        Competition.new(start_date: Date.new(2024, 5, 1), display_name: "MIBM 2024")
+      ]
+      render(OtherCompetitionLinks::Component.new(
+        competitions:,
+        current_competition: competitions[1]
       ))
     end
 

--- a/app/components/punchcard/body/component.rb
+++ b/app/components/punchcard/body/component.rb
@@ -24,7 +24,8 @@ module Punchcard::Body
         {
           date_string:,
           distance_meters: sum_across_users(:distance_meters, date_string),
-          elevation_meters: sum_across_users(:elevation_meters, date_string)
+          elevation_meters: sum_across_users(:elevation_meters, date_string),
+          activity_count: sum_across_users(:activity_count, date_string).to_i
         }
       end
     end

--- a/app/components/punchcard/footer/component.html.erb
+++ b/app/components/punchcard/footer/component.html.erb
@@ -31,5 +31,5 @@
 </div>
 
 <% if @competitions.many? %>
-  <%= render(OtherCompetitionLinks::Component.new(competitions: @competitions, current_year: @competition.year)) %>
+  <%= render(OtherCompetitionLinks::Component.new(competitions: @competitions, current_competition: @competition)) %>
 <% end %>

--- a/app/components/punchcard/ridge/component.rb
+++ b/app/components/punchcard/ridge/component.rb
@@ -57,11 +57,12 @@ module Punchcard::Ridge
         date = Date.parse(day[:date_string])
         day_of_week = date.strftime("%A")
         upcoming = date > today
+        activities = "#{number_with_delimiter(day[:activity_count])} #{"activity".pluralize(day[:activity_count])}"
         {
           height_px:,
           date_string: day[:date_string],
           day: date.day,
-          title: upcoming ? day_of_week : "#{day_of_week}\n#{miles.round(1)} mi\n#{number_with_delimiter(feet.to_i)} ft",
+          title: upcoming ? day_of_week : "#{day_of_week}\n#{activities}\n#{miles.round(1)} mi\n#{number_with_delimiter(feet.to_i)} ft",
           upcoming:,
           weekend_label: (date.strftime("%a") if date.saturday? || date.sunday?)
         }

--- a/app/components/punchcard/user_row/component.rb
+++ b/app/components/punchcard/user_row/component.rb
@@ -17,7 +17,11 @@ module Punchcard::UserRow
     end
 
     def upcoming?(date_string)
-      date_string >= current_date_string
+      return true if date_string > current_date_string
+      # Today defaults to "upcoming" (hidden) so we don't show a premature
+      # "no rides" dot on a day that isn't over — but render it as a punch
+      # once the user has activity on it.
+      date_string == current_date_string && distance_meters_on(date_string).zero?
     end
 
     def current_date_string

--- a/app/components/punchcard/wrapper/component.rb
+++ b/app/components/punchcard/wrapper/component.rb
@@ -6,11 +6,12 @@ module Punchcard::Wrapper
 
     def self.daily_metrics(competition_user)
       activities = competition_user.competition_activities_included
-      Hash.new { |hash, key| hash[key] = {distance_meters: 0.0, elevation_meters: 0.0} }.tap do |result|
+      Hash.new { |hash, key| hash[key] = {distance_meters: 0.0, elevation_meters: 0.0, activity_count: 0} }.tap do |result|
         activities.each do |activity|
           activity.activity_dates_strings.each do |date_string|
             result[date_string][:distance_meters] += activity.distance_meters.to_f
             result[date_string][:elevation_meters] += activity.elevation_meters.to_f
+            result[date_string][:activity_count] += 1
           end
         end
       end

--- a/app/javascript/controllers/punch_controller.js
+++ b/app/javascript/controllers/punch_controller.js
@@ -3,15 +3,19 @@ import { Controller } from '@hotwired/stimulus'
 // Connects to data-controller="punch"
 // Active punches are encoded in the URL as
 //   ?selected=userSlug:day,day;userSlug:day,...
-// and restored on load. History is not pushed.
+// and restored on load. History is not pushed. A separate `days=d,d,...`
+// parameter tracks ridge-bar selection for days that have no punches yet
+// (the user clicked the bar to pre-select a day).
 // Elements with `data-punch-activities-for="<id>"` are revealed when the
 // matching punch is active.
 export default class extends Controller {
   static targets = ['punch', 'ridgeBar', 'userButton', 'hideAllBtn']
 
   connect () {
+    this.selectedEmptyDays = new Set()
     this.indexPunches()
-    const selected = new URLSearchParams(window.location.search).get('selected')
+    const params = new URLSearchParams(window.location.search)
+    const selected = params.get('selected')
     if (selected) {
       selected.split(';').forEach(group => {
         const [slug, daysStr] = group.split(':')
@@ -21,7 +25,19 @@ export default class extends Controller {
         })
       })
     }
+    const days = params.get('days')
+    if (days) {
+      days.split(',').forEach(day => {
+        const date = this.dateStringForDay(parseInt(day, 10))
+        if (date && !this.punchesByDate.has(date)) this.selectedEmptyDays.add(date)
+      })
+    }
     this.sync()
+  }
+
+  dateStringForDay (day) {
+    const bar = this.ridgeBarTargets.find(b => parseInt(b.dataset.date.slice(-2), 10) === day)
+    return bar?.dataset.date
   }
 
   indexPunches () {
@@ -50,7 +66,18 @@ export default class extends Controller {
   }
 
   toggleDay (event) {
-    this.toggleGroup(this.punchesByDate.get(event.currentTarget.dataset.date))
+    const date = event.currentTarget.dataset.date
+    const targets = this.punchesByDate.get(date)
+    if (targets && targets.length > 0) {
+      this.toggleGroup(targets)
+    } else {
+      if (this.selectedEmptyDays.has(date)) {
+        this.selectedEmptyDays.delete(date)
+      } else {
+        this.selectedEmptyDays.add(date)
+      }
+      this.afterToggle()
+    }
   }
 
   toggleUser (event) {
@@ -88,9 +115,12 @@ export default class extends Controller {
 
   syncRidgeBars () {
     this.ridgeBarTargets.forEach(bar => {
-      const targets = this.punchesByDate.get(bar.dataset.date) || []
-      const allActive = targets.length > 0 && targets.every(el => el.getAttribute('aria-pressed') === 'true')
-      bar.setAttribute('aria-pressed', allActive ? 'true' : 'false')
+      const date = bar.dataset.date
+      const targets = this.punchesByDate.get(date) || []
+      const pressed = targets.length > 0
+        ? targets.every(el => el.getAttribute('aria-pressed') === 'true')
+        : this.selectedEmptyDays.has(date)
+      bar.setAttribute('aria-pressed', pressed ? 'true' : 'false')
     })
   }
 
@@ -135,14 +165,16 @@ export default class extends Controller {
     const encoded = Array.from(byUser, ([slug, days]) =>
       `${slug}:${days.sort((a, b) => a - b).join(',')}`
     ).join(';')
+    const emptyDays = Array.from(this.selectedEmptyDays)
+      .map(d => parseInt(d.slice(-2), 10))
+      .sort((a, b) => a - b)
+      .join(',')
     const url = new URL(window.location.href)
-    const current = url.searchParams.get('selected') ?? ''
-    if (encoded === current) return
-    if (encoded) {
-      url.searchParams.set('selected', encoded)
-    } else {
-      url.searchParams.delete('selected')
-    }
+    const currentSelected = url.searchParams.get('selected') ?? ''
+    const currentDays = url.searchParams.get('days') ?? ''
+    if (encoded === currentSelected && emptyDays === currentDays) return
+    if (encoded) url.searchParams.set('selected', encoded); else url.searchParams.delete('selected')
+    if (emptyDays) url.searchParams.set('days', emptyDays); else url.searchParams.delete('days')
     window.history.replaceState(null, '', url)
   }
 }

--- a/app/javascript/controllers/punch_controller.js
+++ b/app/javascript/controllers/punch_controller.js
@@ -3,19 +3,15 @@ import { Controller } from '@hotwired/stimulus'
 // Connects to data-controller="punch"
 // Active punches are encoded in the URL as
 //   ?selected=userSlug:day,day;userSlug:day,...
-// and restored on load. History is not pushed. A separate `days=d,d,...`
-// parameter tracks ridge-bar selection for days that have no punches yet
-// (the user clicked the bar to pre-select a day).
+// and restored on load. History is not pushed.
 // Elements with `data-punch-activities-for="<id>"` are revealed when the
 // matching punch is active.
 export default class extends Controller {
   static targets = ['punch', 'ridgeBar', 'userButton', 'hideAllBtn']
 
   connect () {
-    this.selectedEmptyDays = new Set()
     this.indexPunches()
-    const params = new URLSearchParams(window.location.search)
-    const selected = params.get('selected')
+    const selected = new URLSearchParams(window.location.search).get('selected')
     if (selected) {
       selected.split(';').forEach(group => {
         const [slug, daysStr] = group.split(':')
@@ -25,19 +21,7 @@ export default class extends Controller {
         })
       })
     }
-    const days = params.get('days')
-    if (days) {
-      days.split(',').forEach(day => {
-        const date = this.dateStringForDay(parseInt(day, 10))
-        if (date && !this.punchesByDate.has(date)) this.selectedEmptyDays.add(date)
-      })
-    }
     this.sync()
-  }
-
-  dateStringForDay (day) {
-    const bar = this.ridgeBarTargets.find(b => parseInt(b.dataset.date.slice(-2), 10) === day)
-    return bar?.dataset.date
   }
 
   indexPunches () {
@@ -66,18 +50,7 @@ export default class extends Controller {
   }
 
   toggleDay (event) {
-    const date = event.currentTarget.dataset.date
-    const targets = this.punchesByDate.get(date)
-    if (targets && targets.length > 0) {
-      this.toggleGroup(targets)
-    } else {
-      if (this.selectedEmptyDays.has(date)) {
-        this.selectedEmptyDays.delete(date)
-      } else {
-        this.selectedEmptyDays.add(date)
-      }
-      this.afterToggle()
-    }
+    this.toggleGroup(this.punchesByDate.get(event.currentTarget.dataset.date))
   }
 
   toggleUser (event) {
@@ -115,12 +88,9 @@ export default class extends Controller {
 
   syncRidgeBars () {
     this.ridgeBarTargets.forEach(bar => {
-      const date = bar.dataset.date
-      const targets = this.punchesByDate.get(date) || []
-      const pressed = targets.length > 0
-        ? targets.every(el => el.getAttribute('aria-pressed') === 'true')
-        : this.selectedEmptyDays.has(date)
-      bar.setAttribute('aria-pressed', pressed ? 'true' : 'false')
+      const targets = this.punchesByDate.get(bar.dataset.date) || []
+      const allActive = targets.length > 0 && targets.every(el => el.getAttribute('aria-pressed') === 'true')
+      bar.setAttribute('aria-pressed', allActive ? 'true' : 'false')
     })
   }
 
@@ -165,16 +135,14 @@ export default class extends Controller {
     const encoded = Array.from(byUser, ([slug, days]) =>
       `${slug}:${days.sort((a, b) => a - b).join(',')}`
     ).join(';')
-    const emptyDays = Array.from(this.selectedEmptyDays)
-      .map(d => parseInt(d.slice(-2), 10))
-      .sort((a, b) => a - b)
-      .join(',')
     const url = new URL(window.location.href)
-    const currentSelected = url.searchParams.get('selected') ?? ''
-    const currentDays = url.searchParams.get('days') ?? ''
-    if (encoded === currentSelected && emptyDays === currentDays) return
-    if (encoded) url.searchParams.set('selected', encoded); else url.searchParams.delete('selected')
-    if (emptyDays) url.searchParams.set('days', emptyDays); else url.searchParams.delete('days')
+    const current = url.searchParams.get('selected') ?? ''
+    if (encoded === current) return
+    if (encoded) {
+      url.searchParams.set('selected', encoded)
+    } else {
+      url.searchParams.delete('selected')
+    }
     window.history.replaceState(null, '', url)
   }
 }

--- a/app/views/competitions_original/show.html.erb
+++ b/app/views/competitions_original/show.html.erb
@@ -1,3 +1,3 @@
 <%= render partial: "competitions_original/#{@year}" %>
 
-<%= render(OtherCompetitionLinks::Component.new(competitions: @competitions, current_year: @year.to_i, original_view: true)) %>
+<%= render(OtherCompetitionLinks::Component.new(competitions: @competitions, current_competition: @competitions.find { |c| c.year == @year.to_i }, original_view: true)) %>

--- a/spec/components/other_competition_links/component_spec.rb
+++ b/spec/components/other_competition_links/component_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe OtherCompetitionLinks::Component, type: :component do
   let!(:competition_2025) { FactoryBot.create(:competition, start_date: Date.new(2025, 5, 1)) }
   let!(:competition_2026) { FactoryBot.create(:competition, start_date: Date.new(2026, 5, 1)) }
   let(:competitions) { Competition.start_ordered_desc }
-  let(:current_year) { 2026 }
+  let(:current_competition) { competition_2026 }
   let(:original_view) { false }
   let(:component) do
-    render_inline(described_class.new(competitions:, current_year:, original_view:))
+    render_inline(described_class.new(competitions:, current_competition:, original_view:))
   end
 
   it "renders competitions in the given order" do
@@ -27,7 +27,7 @@ RSpec.describe OtherCompetitionLinks::Component, type: :component do
 
   context "when original_view is true" do
     let(:original_view) { true }
-    let(:current_year) { 2024 }
+    let(:current_competition) { competition_2024 }
 
     it "links to competitions_original_path" do
       expect(component).to have_css("span[title=\"You're looking at it\"]", text: "2024")
@@ -40,12 +40,39 @@ RSpec.describe OtherCompetitionLinks::Component, type: :component do
     let(:competitions) do
       %w[2025 2024].map { |y| Competition.new(start_date: Date.new(y.to_i, 5, 1)) }
     end
-    let(:current_year) { 2024 }
+    let(:current_competition) { competitions.last }
     let(:original_view) { true }
 
     it "renders using year without needing a slug" do
       expect(component).to have_css("span[title=\"You're looking at it\"]", text: "2024")
       expect(component).to have_css("a.twlink[href='/competitions_original/2025']", text: "2025")
+    end
+  end
+
+  context "when multiple competitions exist for the same year" do
+    let!(:competition_2025_fall) do
+      FactoryBot.create(:competition, start_date: Date.new(2025, 9, 1), end_date: Date.new(2025, 9, 30), display_name: "MIBM Fall 2025")
+    end
+    let(:current_competition) { competition_2025 }
+
+    it "appends the display name in xs non-bold text inside each link for dup years, marks only the current one" do
+      fall_link = component.css("a.twlink[href='/competitions/#{competition_2025_fall.slug}']").first
+      suffix = fall_link.at_css("span.text-xs")
+      expect(suffix.text).to include "(MIBM Fall 2025)"
+      expect(suffix["class"]).to include "font-normal"
+      expect(fall_link.text).to include "2025"
+
+      current_span = component.css("span[title=\"You're looking at it\"]").first
+      expect(current_span.at_css("span.text-xs").text).to include "(#{competition_2025.display_name})"
+
+      # 2026 has a single competition — no suffix
+      year_2026 = component.css("a.twlink[href='/competitions/#{competition_2026.slug}']").first
+      expect(year_2026.at_css("span.text-xs")).to be_nil
+      expect(year_2026.text.strip).to eq "2026"
+
+      # Only the matching current competition is disabled; the sibling stays clickable.
+      expect(component).to have_css("span[title=\"You're looking at it\"]", text: "2025", count: 1)
+      expect(component).to have_css("a.twlink[href='/competitions/#{competition_2025_fall.slug}']", text: "2025")
     end
   end
 end

--- a/spec/components/punchcard/ridge/component_spec.rb
+++ b/spec/components/punchcard/ridge/component_spec.rb
@@ -5,29 +5,33 @@ require "rails_helper"
 RSpec.describe Punchcard::Ridge::Component, type: :component do
   let(:daily_totals) do
     [
-      {date_string: "2025-05-01", distance_meters: 100_000, elevation_meters: 500},
-      {date_string: "2025-05-02", distance_meters: 50_000, elevation_meters: 200},
-      {date_string: "2025-05-03", distance_meters: 0, elevation_meters: 0}
+      {date_string: "2025-05-01", distance_meters: 100_000, elevation_meters: 500, activity_count: 3},
+      {date_string: "2025-05-02", distance_meters: 50_000, elevation_meters: 200, activity_count: 1},
+      {date_string: "2025-05-03", distance_meters: 0, elevation_meters: 0, activity_count: 0}
     ]
   end
   let(:rendered) { render_inline(described_class.new(daily_totals:)) }
 
-  it "scales bar heights in pixels up to the max" do
+  it "renders each day's button with scaled bar height, day number, and a title of day-of-week, activity count, miles, feet" do
+    buttons = rendered.css("button")
     bars = rendered.css("button span[style]")
+    expect(buttons.count).to eq 3
     expect(bars.count).to eq 3
+
     expect(bars[0].attr("style")).to include "height:56.0px"
     expect(bars[1].attr("style")).to include "height:28.0px"
     expect(bars[2].attr("style")).to include "height:0.0px"
+
+    expect(buttons[0].text).to include "1"
+    expect(buttons[0].attr("title").lines.map(&:chomp)).to eq ["Thursday", "3 activities", "62.1 mi", "1,640 ft"]
+    expect(buttons[1].attr("title").lines.map(&:chomp)).to include "1 activity"
+    expect(buttons[2].attr("title").lines.map(&:chomp)).to include "0 activities"
   end
 
-  it "renders each button with day number and a title containing the day of week, miles and feet" do
-    buttons = rendered.css("button")
-    expect(buttons.count).to eq 3
-    expect(buttons[0].text).to include "1"
-    title = buttons[0].attr("title")
-    expect(title).to include "Thursday"
-    expect(title).to include "mi"
-    expect(title).to include "ft"
+  it "formats large activity counts with a delimiter" do
+    daily_totals = [{date_string: "2025-05-01", distance_meters: 10_000, elevation_meters: 0, activity_count: 1_234}]
+    title = render_inline(described_class.new(daily_totals:)).css("button").first.attr("title")
+    expect(title).to include "1,234 activities"
   end
 
   context "when all totals are zero" do

--- a/spec/components/punchcard/user_row/component_spec.rb
+++ b/spec/components/punchcard/user_row/component_spec.rb
@@ -106,9 +106,6 @@ RSpec.describe Punchcard::UserRow::Component, type: :component do
     end
 
     context "when current_date has rolled into tomorrow for this user (eastward timezone)" do
-      # Simulates the timezone case: it's still 4/16 for the viewer but the
-      # competition_user's timezone puts them at 4/17 with no activity yet.
-      # We must not render an "x" for 4/17.
       before { allow(competition_user).to receive(:current_date).and_return(Date.parse("2026-04-17")) }
 
       it "keeps 4/17 as an upcoming plain span (no x) when there's no activity" do
@@ -119,9 +116,6 @@ RSpec.describe Punchcard::UserRow::Component, type: :component do
     end
   end
 
-  # Exercises the real timezone resolution: current_date comes from
-  # Time.current evaluated in the user's timezone (derived from their latest
-  # activity). Nothing past that cutoff may render an "x".
   describe "upcoming-day cutoff honors the user's current timezone" do
     let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2026-04-01")) }
     let(:period_date_strings) { (competition.start_date..competition.end_date).map(&:to_s) }

--- a/spec/components/punchcard/user_row/component_spec.rb
+++ b/spec/components/punchcard/user_row/component_spec.rb
@@ -83,14 +83,78 @@ RSpec.describe Punchcard::UserRow::Component, type: :component do
     let(:user_daily) { {} }
     around { |ex| travel_to(Date.parse("2026-04-16")) { ex.run } }
 
-    it "renders empty spans for today and future, punchcard-cells for past days" do
-      cells = rendered.css("div.h-7 > span")
-      expect(cells.count).to eq 30
+    it "renders past days as cells, today+future as plain spans, and shows days_so_far through today" do
+      expect(rendered.css("div.h-7 > *").count).to eq 30
+      # past (15) = 15 cells; today + future (15) stay plain spans until activity lands
       expect(rendered.css("div.h-7 .punchcard-cell").count).to eq 15
+      expect(rendered.text).to include "/16"
     end
 
-    it "uses days_so_far (days through current_date, inclusive) as the denominator" do
-      expect(rendered.text).to include "/16"
+    context "when the user has activity today" do
+      let(:user_daily) { {"2026-04-16" => {distance_meters: 16_093, elevation_meters: 100}} }
+      let!(:today_activity) do
+        FactoryBot.create(:competition_activity,
+          competition_user:, distance_meters: 16_093, start_at: Time.parse("2026-04-16T15:00:00Z"))
+      end
+
+      it "renders today as a clickable punch button and includes its activity in the punch-activities-container" do
+        today_cell = rendered.css("div.h-7 > *")[15]
+        expect(today_cell.name).to eq "button"
+        expect(today_cell["data-date"]).to eq "2026-04-16"
+        expect(rendered.css(%([data-punch-activities-for="#{user.slug}-2026-04-16"])).count).to eq 1
+      end
+    end
+
+    context "when current_date has rolled into tomorrow for this user (eastward timezone)" do
+      # Simulates the timezone case: it's still 4/16 for the viewer but the
+      # competition_user's timezone puts them at 4/17 with no activity yet.
+      # We must not render an "x" for 4/17.
+      before { allow(competition_user).to receive(:current_date).and_return(Date.parse("2026-04-17")) }
+
+      it "keeps 4/17 as an upcoming plain span (no x) when there's no activity" do
+        tomorrow_cell = rendered.css("div.h-7 > *")[16]
+        expect(tomorrow_cell.name).to eq "span"
+        expect(tomorrow_cell["class"]).to be_nil
+      end
+    end
+  end
+
+  # Exercises the real timezone resolution: current_date comes from
+  # Time.current evaluated in the user's timezone (derived from their latest
+  # activity). Nothing past that cutoff may render an "x".
+  describe "upcoming-day cutoff honors the user's current timezone" do
+    let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2026-04-01")) }
+    let(:period_date_strings) { (competition.start_date..competition.end_date).map(&:to_s) }
+    let(:user_daily) { {} }
+
+    # Viewer wall-clock: 2026-04-16 23:00 UTC-7 (still the 16th).
+    # Same instant in America/Chicago: 2026-04-17 01:00 — so for a Chicago
+    # rider current_date = 4/17 even though the viewer thinks it's 4/16.
+    around { |ex| travel_to(Time.parse("2026-04-17T06:00:00Z")) { ex.run } }
+
+    before do
+      FactoryBot.create(:competition_activity,
+        competition_user:,
+        timezone: "America/Chicago",
+        start_at: Time.parse("2026-04-10T15:00:00Z"))
+    end
+
+    it "renders no x on or after the user's current_date" do
+      expect(competition_user.current_date.to_s).to eq "2026-04-17"
+
+      period_date_strings.each_with_index do |date_string, idx|
+        el = rendered.css("div.h-7 > *")[idx]
+        past = date_string < competition_user.current_date.to_s
+        if past
+          # past days with no activity render the "x" cell
+          expect(el["class"]).to include("punchcard-cell"),
+            "expected #{date_string} to be a past 'x' cell"
+        else
+          # today (4/17 here) and beyond stay hidden — no x yet
+          expect(el["class"]).to be_nil,
+            "expected #{date_string} to be an upcoming plain span (no x), got class=#{el["class"].inspect}"
+        end
+      end
     end
   end
 end

--- a/spec/components/punchcard/wrapper/component_spec.rb
+++ b/spec/components/punchcard/wrapper/component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Punchcard::Wrapper::Component, type: :component do
 
     context "with no activities" do
       it "returns an empty-default hash" do
-        expect(described_class.daily_metrics(competition_user)["2025-05-01"]).to eq(distance_meters: 0.0, elevation_meters: 0.0)
+        expect(described_class.daily_metrics(competition_user)["2025-05-01"]).to eq(distance_meters: 0.0, elevation_meters: 0.0, activity_count: 0)
       end
     end
 
@@ -30,11 +30,19 @@ RSpec.describe Punchcard::Wrapper::Component, type: :component do
           elevation_meters: 300,
           start_at: Time.parse("2025-05-03T15:00:00Z"))
       end
+      let!(:second_activity) do
+        FactoryBot.create(:competition_activity,
+          competition_user:,
+          distance_meters: 1_000,
+          elevation_meters: 50,
+          start_at: Time.parse("2025-05-03T20:00:00Z"))
+      end
 
-      it "sums distance and elevation for each activity date" do
+      it "sums distance, elevation, and ride counts for each activity date" do
         metrics = described_class.daily_metrics(competition_user)
-        expect(metrics["2025-05-03"][:distance_meters]).to be_within(0.01).of(16_093.44)
-        expect(metrics["2025-05-03"][:elevation_meters]).to eq 300.0
+        expect(metrics["2025-05-03"][:distance_meters]).to be_within(0.01).of(17_093.44)
+        expect(metrics["2025-05-03"][:elevation_meters]).to eq 350.0
+        expect(metrics["2025-05-03"][:activity_count]).to eq 2
       end
     end
   end

--- a/spec/services/strava_integration_spec.rb
+++ b/spec/services/strava_integration_spec.rb
@@ -27,8 +27,10 @@ RSpec.describe StravaIntegration, type: :model do
 
   describe "get_activities narrowed to activity 18111714404" do
     # Activity 18111714404 starts at 2026-04-14T23:03:36Z. Use before/after
-    # query parameters to fetch a window containing exactly that activity so
-    # we can inspect its strava_data payload.
+    # query parameters to fetch a window containing exactly that activity,
+    # then create a CompetitionActivity from the returned strava_data so we
+    # can pin down exactly how the Peloton-→-Strava Central-time ride maps
+    # onto our model.
     let(:access_token) { ENV.fetch("STRAVA_RECORD_TOKEN", "xxxx") }
     let(:activity_id) { 18_111_714_404 }
     let(:parameters) do
@@ -38,18 +40,29 @@ RSpec.describe StravaIntegration, type: :model do
         per_page: 10
       }
     end
-    let(:result) { described_class.get_activities(access_token, parameters:) }
+    let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2026-04-01")) }
+    let(:competition_user) { FactoryBot.create(:competition_user, competition:) }
 
-    it "returns activity 18111714404 with its strava_data payload" do
+    it "creates a CompetitionActivity from the returned strava_data with the expected attributes" do
       VCR.use_cassette("strava_integration-get_activity-18111714404", match_requests_on: [:path]) do
+        result = described_class.get_activities(access_token, parameters:)
         expect(result["status"]).to eq 200
-        activity = result["json"].find { |a| a["id"] == activity_id }
-        expect(activity).not_to be_nil
-        # Surface a handful of fields so `rspec --format documentation` shows
-        # the shape of the payload (useful for debugging timezone quirks).
-        %w[name type trainer timezone start_date_local utc_offset].each do |key|
-          puts "  strava_data[#{key.inspect}] = #{activity[key].inspect}"
-        end
+
+        strava_data = result["json"].find { |a| a["id"] == activity_id }
+        activity = CompetitionActivity.find_or_create_if_valid(competition_user:, strava_data:)
+
+        expect(activity).to be_valid
+        expect(activity).to have_attributes(
+          strava_id: "18111714404",
+          display_name: "20 min HIIT Ride with Emma Lovewell",
+          timezone: "America/Chicago",
+          start_at: Time.parse("2026-04-14T23:03:36Z"),
+          distance_meters: 12_027.3,
+          moving_seconds: 1200,
+          elevation_meters: 0.0,
+          activity_dates_strings: ["2026-04-14"],
+          included_in_competition: true
+        )
       end
     end
   end

--- a/spec/services/strava_integration_spec.rb
+++ b/spec/services/strava_integration_spec.rb
@@ -25,6 +25,35 @@ RSpec.describe StravaIntegration, type: :model do
     end
   end
 
+  describe "get_activities narrowed to activity 18111714404" do
+    # Activity 18111714404 starts at 2026-04-14T23:03:36Z. Use before/after
+    # query parameters to fetch a window containing exactly that activity so
+    # we can inspect its strava_data payload.
+    let(:access_token) { ENV.fetch("STRAVA_RECORD_TOKEN", "xxxx") }
+    let(:activity_id) { 18_111_714_404 }
+    let(:parameters) do
+      {
+        after: Time.utc(2026, 4, 14).to_i,
+        before: Time.utc(2026, 4, 15).to_i,
+        per_page: 10
+      }
+    end
+    let(:result) { described_class.get_activities(access_token, parameters:) }
+
+    it "returns activity 18111714404 with its strava_data payload" do
+      VCR.use_cassette("strava_integration-get_activity-18111714404", match_requests_on: [:path]) do
+        expect(result["status"]).to eq 200
+        activity = result["json"].find { |a| a["id"] == activity_id }
+        expect(activity).not_to be_nil
+        # Surface a handful of fields so `rspec --format documentation` shows
+        # the shape of the payload (useful for debugging timezone quirks).
+        %w[name type trainer timezone start_date_local utc_offset].each do |key|
+          puts "  strava_data[#{key.inspect}] = #{activity[key].inspect}"
+        end
+      end
+    end
+  end
+
   describe "get_activities" do
     let(:access_token) { "xxxx" }
     let(:result) { described_class.get_activities(access_token, parameters: {per_page: 1}) }

--- a/spec/vcr_cassettes/strava_integration-get_activity-18111714404.yml
+++ b/spec/vcr_cassettes/strava_integration-get_activity-18111714404.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.strava.com/api/v3/athlete/activities?after=1776124800&before=1776211200&per_page=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.14.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 21 Apr 2026 06:31:27 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '201'
+      Server:
+      - istio-envoy
+      Status:
+      - 200 OK
+      X-Ratelimit-Usage:
+      - '1,6'
+      X-Ratelimit-Limit:
+      - '600,6000'
+      Vary:
+      - Accept, Origin
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - ecd9c0a2-4bc7-406b-b5d0-ccf43545aa2f
+      X-Readratelimit-Limit:
+      - '300,3000'
+      X-Download-Options:
+      - noopen
+      Etag:
+      - W/"05271a60c61a7556b74f7211518cdb4c"
+      X-Frame-Options:
+      - DENY
+      X-Readratelimit-Usage:
+      - '1,6'
+      X-Content-Type-Options:
+      - nosniff
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 646b231fddd116a809b791efe727aba6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SFO53-P5
+      X-Amz-Cf-Id:
+      - HGyw95doFjnzgnRZCkPz-iOJzGYaPBxUcHXZiptEWYUU2oXGvME8mQ==
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"resource_state":2,"athlete":{"id":2430215,"resource_state":1},"name":"20
+        min HIIT Ride with Emma Lovewell","distance":12027.3,"moving_time":1200,"elapsed_time":1200,"total_elevation_gain":0,"type":"Ride","sport_type":"Ride","workout_type":null,"device_name":"Peloton
+        Bike","id":18111714404,"start_date":"2026-04-14T23:03:36Z","start_date_local":"2026-04-14T18:03:36Z","timezone":"(GMT-06:00)
+        America/Chicago","utc_offset":-18000.0,"location_city":null,"location_state":null,"location_country":null,"achievement_count":0,"kudos_count":2,"comment_count":0,"athlete_count":9,"photo_count":0,"map":{"id":"a18111714404","summary_polyline":"","resource_state":2},"trainer":true,"commute":false,"manual":false,"private":false,"visibility":"everyone","flagged":false,"gear_id":null,"start_latlng":[],"end_latlng":[],"average_speed":10.023,"max_speed":13.5,"average_cadence":89.3,"average_watts":238.0,"max_watts":436,"weighted_average_watts":260,"device_watts":true,"kilojoules":285.6,"has_heartrate":true,"average_heartrate":148.8,"max_heartrate":180.0,"heartrate_opt_out":false,"display_hide_heartrate_option":true,"elev_high":0.0,"elev_low":0.0,"upload_id":19213576024,"upload_id_str":"19213576024","external_id":"230e11824b024dc98164749fd72826e2.tcx","from_accepted_tag":false,"pr_count":0,"total_photo_count":1,"has_kudoed":false,"suffer_score":14.0}]'
+  recorded_at: Tue, 21 Apr 2026 06:31:27 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Cleanup pieces pulled from #92 that aren't tied to the live-update machinery.
