### PR TITLE
Use UI::Button link color for show/hide activities buttons

### DIFF
--- a/app/components/leaderboard/punchcard_body/component.html.erb
+++ b/app/components/leaderboard/punchcard_body/component.html.erb
@@ -19,32 +19,19 @@
         lg:border-b lg:border-purple-100 lg:dark:border-purple-700 lg:pb-2
       "
     >
-      <button
-        type="button"
-        class="
-          text-purple-300 dark:text-purple-400 hover:text-purple-500
-          dark:hover:text-purple-200 hover:underline cursor-pointer
-          aria-pressed:text-purple-500 dark:aria-pressed:text-purple-200
-          aria-pressed:underline
-        "
-        aria-pressed="false"
-        data-action="click->punch#showAll"
-        data-punch-target="showAllBtn"
-      >
-        Show all activities
-      </button>
+      <%= render(UI::Button::Component.new(
+        text: "Show all activities",
+        color: :link,
+        aria: {pressed: "false"},
+        data: {action: "click->punch#showAll", punch_target: "showAllBtn"}
+      )) %>
 
-      <button
-        type="button"
-        class="
-          hidden text-purple-300 dark:text-purple-400 hover:text-purple-500
-          dark:hover:text-purple-200 hover:underline cursor-pointer
-        "
-        data-action="click->punch#hideAll"
-        data-punch-target="hideAllBtn"
-      >
-        Hide all activities
-      </button>
+      <%= render(UI::Button::Component.new(
+        text: "Hide all activities",
+        color: :link,
+        html_class: "hidden",
+        data: {action: "click->punch#hideAll", punch_target: "hideAllBtn"}
+      )) %>
     </div>
 
     <div

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -15,14 +15,14 @@ module UI
         primary: "text-white bg-purple-500 border border-purple-500 hover:bg-purple-600 active:bg-purple-700 focus:ring-purple-400/40 dark:bg-purple-400 dark:border-purple-400 dark:hover:bg-purple-500 dark:active:bg-purple-600",
         secondary: "text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 hover:border-gray-400 active:bg-gray-100 focus:ring-purple-400/40 dark:text-gray-200 dark:bg-gray-800 dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-500 dark:active:bg-gray-600",
         error: "text-white bg-red-600 border border-red-600 hover:bg-red-700 active:bg-red-800 focus:ring-red-500/40 dark:bg-red-500 dark:border-red-500 dark:hover:bg-red-600 dark:active:bg-red-700",
-        link: "text-purple-300 dark:text-purple-400 hover:text-purple-500 dark:hover:text-purple-200 hover:underline aria-pressed:text-purple-500 aria-pressed:underline dark:aria-pressed:text-purple-200"
+        link: "text-purple-300 dark:text-purple-400 hover:text-purple-500 dark:hover:text-purple-200 active:underline hover:underline aria-pressed:text-purple-500 aria-pressed:underline aria-pressed:font-bold dark:aria-pressed:text-purple-200 active:font-bold"
       }.freeze
 
       ACTIVE_COLORS = {
         primary: "ring-2 ring-purple-400/40 bg-purple-600 dark:bg-purple-500",
         secondary: "ring-2 ring-purple-400/40 bg-gray-100 border-gray-400 dark:bg-gray-700 dark:border-gray-500",
         error: "ring-2 ring-red-500/40 bg-red-700 dark:bg-red-600",
-        link: "text-purple-500 dark:text-purple-200 underline"
+        link: "text-purple-500 dark:text-purple-200 underline font-bold"
       }.freeze
 
       KINDS = %i[button submit]

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -15,14 +15,14 @@ module UI
         primary: "text-white bg-purple-500 border border-purple-500 hover:bg-purple-600 active:bg-purple-700 focus:ring-purple-400/40 dark:bg-purple-400 dark:border-purple-400 dark:hover:bg-purple-500 dark:active:bg-purple-600",
         secondary: "text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 hover:border-gray-400 active:bg-gray-100 focus:ring-purple-400/40 dark:text-gray-200 dark:bg-gray-800 dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-500 dark:active:bg-gray-600",
         error: "text-white bg-red-600 border border-red-600 hover:bg-red-700 active:bg-red-800 focus:ring-red-500/40 dark:bg-red-500 dark:border-red-500 dark:hover:bg-red-600 dark:active:bg-red-700",
-        link: "text-purple-500 hover:text-purple-700 dark:text-purple-300 dark:hover:text-purple-200 underline active:text-purple-700 active:dark:text-purple-200 active:font-bold p-0 focus:ring-1"
+        link: "text-purple-300 dark:text-purple-400 hover:text-purple-500 dark:hover:text-purple-200 hover:underline aria-pressed:text-purple-500 aria-pressed:underline dark:aria-pressed:text-purple-200"
       }.freeze
 
       ACTIVE_COLORS = {
         primary: "ring-2 ring-purple-400/40 bg-purple-600 dark:bg-purple-500",
         secondary: "ring-2 ring-purple-400/40 bg-gray-100 border-gray-400 dark:bg-gray-700 dark:border-gray-500",
         error: "ring-2 ring-red-500/40 bg-red-700 dark:bg-red-600",
-        link: "text-purple-700 dark:text-purple-200 font-bold"
+        link: "text-purple-500 dark:text-purple-200 underline"
       }.freeze
 
       KINDS = %i[button submit]
@@ -37,13 +37,14 @@ module UI
         classes.compact.join(" ")
       end
 
-      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, data: {})
+      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, data: {}, aria: {})
         @text = text
         @color = COLORS.key?(color) ? color : :secondary
         @kind = KINDS.include?(kind&.to_sym) ? kind.to_sym : KINDS.first
         @active = active
         @html_class = html_class
         @data = data
+        @aria = aria
         @size = SIZES.key?(size) ? size : :md
         raise ArgumentError, "size is not supported for link color" if @color == :link && @size != :md
       end
@@ -53,7 +54,7 @@ module UI
       end
 
       def call
-        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", data: @data)
+        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", data: @data, aria: @aria)
       end
     end
   end


### PR DESCRIPTION
- Retuned `UI::Button::Component` `:link` color to the lighter show/hide styling (underline on hover/aria-pressed, no default underline).
- Added an `aria:` option on `UI::Button::Component` so callers can pass `aria-pressed`.
- Replaced the raw `<button>` markup for "Show all activities" / "Hide all activities" with `UI::Button::Component.new(color: :link)`.
