### PR TITLE
Add admin user edit page with display_name

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,11 +2,31 @@ module Admin
   class UsersController < Admin::BaseController
     include Binxtils::SortableTable
 
+    before_action :find_user, except: [:index]
+
     def index
       @matching_users = searched_users
       @users = @matching_users
         .reorder("users.#{sort_column} #{sort_direction}")
         .includes(:competition_users)
+    end
+
+    def edit
+      @competition_users = @user.competition_users
+        .includes(:competition, :competition_activities)
+        .start_ordered_desc
+    end
+
+    def update
+      if @user.update(permitted_params)
+        flash[:success] = "User updated"
+        redirect_to(admin_users_path, status: :see_other)
+      else
+        @competition_users = @user.competition_users
+          .includes(:competition, :competition_activities)
+          .start_ordered_desc
+        render(:edit, status: :see_other)
+      end
     end
 
     private
@@ -18,6 +38,14 @@ module Admin
     def searched_users
       @time_range_column = %w[last_sign_in_at updated_at].include?(sort_column) ? sort_column : "created_at"
       User.where(@time_range_column => @time_range)
+    end
+
+    def permitted_params
+      params.require(:user).permit(:display_name)
+    end
+
+    def find_user
+      @user = User.friendly_find!(params[:id])
     end
   end
 end

--- a/app/views/admin/competition_users/_table.html.erb
+++ b/app/views/admin/competition_users/_table.html.erb
@@ -1,0 +1,28 @@
+<%# Local vars because cell blocks run via instance_exec in the table component context %>
+<% show_dev_info = display_dev_info? %>
+<% include_competition = local_assigns.fetch(:include_competition, true) %>
+<% render_sortable = local_assigns.fetch(:render_sortable, true) %>
+
+<%= render(UI::Table::Component.new(records: competition_users, render_sortable:, sticky: true)) do |table|
+  table.column(sortable: "created_at", lower_right: (->(cu) { cu.id } if show_dev_info)) do |cu|
+    render(UI::Time::Component.new(time: cu.created_at))
+  end
+
+  table.column(sortable: "display_name") do |cu|
+    link_to(cu.display_name, edit_admin_competition_user_path(cu), class: "twlink")
+  end
+
+  if include_competition
+    table.column(sortable: "competition_id") { |cu| cu.competition.display_name }
+  end
+
+  if show_dev_info
+    table.column(sortable: "updated_at") do |cu|
+      render(UI::Time::Component.new(time: cu.updated_at))
+    end
+  end
+
+  table.column(label: "Activities") { |cu| number_display(cu.competition_activities.count) }
+
+  table.column(label: "Included?") { |cu| check_mark if cu.included_in_competition }
+end %>

--- a/app/views/admin/competition_users/index.html.erb
+++ b/app/views/admin/competition_users/index.html.erb
@@ -1,30 +1,6 @@
 <%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_competition_users, time_range: @time_range, time_range_column: @time_range_column)) %>
 
-<% include_competition ||= competition_subject.blank? %>
-
-<%# Local var because cell blocks run via instance_exec in the table component context %>
-<% show_dev_info = display_dev_info? %>
-
-<%= render(UI::Table::Component.new(records: @competition_users, render_sortable: true, sticky: true)) do |table|
-  table.column(sortable: "created_at", lower_right: (->(cu) { cu.id } if show_dev_info)) do |cu|
-    render(UI::Time::Component.new(time: cu.created_at))
-  end
-
-  table.column(sortable: "display_name") do |cu|
-    link_to(cu.display_name, edit_admin_competition_user_path(cu), class: "twlink")
-  end
-
-  if include_competition
-    table.column(sortable: "competition_id") { |cu| cu.competition.display_name }
-  end
-
-  if show_dev_info
-    table.column(sortable: "updated_at") do |cu|
-      render(UI::Time::Component.new(time: cu.updated_at))
-    end
-  end
-
-  table.column(label: "Activities") { |cu| number_display(cu.competition_activities.count) }
-
-  table.column(label: "Included?") { |cu| check_mark if cu.included_in_competition }
-end %>
+<%= render partial: "admin/competition_users/table", locals: {
+  competition_users: @competition_users,
+  include_competition: competition_subject.blank?
+} %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,56 @@
+<h1 class="mb-4">Edit User</h1>
+
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8">
+  <%= render(UI::DefinitionList::Component.new) do |list| %>
+    <% list.with_entry(label: "Joined") do %>
+      <%= render UI::Time::Component.new(time: @user.created_at) %>
+    <% end %>
+
+    <% list.with_entry(label: "Last sign-in") do %>
+      <% if @user.last_sign_in_at %>
+        <%= render UI::Time::Component.new(time: @user.last_sign_in_at) %>
+      <% else %>
+        <em>never</em>
+      <% end %>
+    <% end %>
+
+    <% list.with_entry(label: "Sign-in count") { @user.sign_in_count } %>
+
+    <% list.with_entry(label: "Role") { @user.role } %>
+  <% end %>
+
+  <%= render(UI::DefinitionList::Component.new) do |list| %>
+    <% if @user.strava_username.present? %>
+      <% list.with_entry(label: "Strava") do %>
+        <%= link_to @user.strava_username, @user.strava_user_url, target: "_blank", class: "twlink" %>
+      <% end %>
+    <% end %>
+
+    <% list.with_entry(label: "Competitions") do %>
+      <%= link_to number_display(@competition_users.size), admin_competition_users_path(user: @user.slug), class: "twlink" %>
+    <% end %>
+  <% end %>
+</div>
+
+<%= form_with(model: @user, url: admin_user_path(@user), method: :patch, builder: MayIsBikeMonthFormBuilder, class: "pb-2") do |f| %>
+  <%= render partial: "/shared/errors", locals: {obj: @user, name: "User"} %>
+
+  <div class="row sm:grid-cols-2">
+    <div class="col">
+      <%= render Form::Group::Component.new(form_builder: f, attribute: :display_name, html_options: {required: true}) %>
+    </div>
+  </div>
+
+  <div class="form-row-btn">
+    <%= f.submit "save", class: "btn" %>
+  </div>
+<% end %>
+
+<% if @competition_users.any? %>
+  <h2 class="mt-8 mb-4 text-lg font-semibold">Competitions</h2>
+  <%= render partial: "admin/competition_users/table", locals: {
+    competition_users: @competition_users,
+    include_competition: true,
+    render_sortable: false
+  } %>
+<% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -9,7 +9,7 @@
   end
 
   table.column(sortable: "display_name") do |user|
-    user.display_name
+    link_to(user.display_name, edit_admin_user_path(user), class: "twlink")
   end
 
   table.column(sortable: "last_sign_in_at", label: "Last sign in") do |user|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     resources :competitions, only: %i[index new create]
     resources :competition_users, only: %i[index edit update]
     resources :strava_requests, only: %i[index]
-    resources :users, only: %i[index]
+    resources :users, only: %i[index edit update]
   end
 
   mount Lookbook::Engine, at: "/lookbook" if defined?(Lookbook)

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe base_url, type: :request do
           ids = assigns(:users).pluck(:id)
           expect(ids.index(newer_user.id)).to be < ids.index(older_user.id)
           expect(response.body).to include(admin_competition_users_path(user: newer_user.slug))
+          expect(response.body).to include(edit_admin_user_path(newer_user))
 
           get "#{base_url}?sort=last_sign_in_at&direction=desc"
           expect(response.code).to eq "200"
@@ -42,6 +43,32 @@ RSpec.describe base_url, type: :request do
           ids = assigns(:users).pluck(:id)
           expect(ids.index(older_user.id)).to be < ids.index(newer_user.id)
         end
+      end
+    end
+
+    describe "edit" do
+      let(:other_user) { FactoryBot.create(:user) }
+      let!(:competition_user) { FactoryBot.create(:competition_user, user: other_user) }
+
+      it "renders" do
+        get "#{base_url}/#{other_user.id}/edit"
+        expect(response.code).to eq "200"
+        expect(response).to render_template("admin/users/edit")
+        expect(assigns(:user)).to eq other_user
+        expect(assigns(:competition_users).pluck(:id)).to eq([competition_user.id])
+        expect(response.body).to include(edit_admin_competition_user_path(competition_user))
+      end
+    end
+
+    describe "update" do
+      let(:other_user) { FactoryBot.create(:user, display_name: "Old Name") }
+      let(:valid_params) { {display_name: "New Name"} }
+
+      it "updates display_name" do
+        patch "#{base_url}/#{other_user.id}", params: {user: valid_params}
+        expect(flash[:success]).to be_present
+        expect(response).to redirect_to admin_users_path
+        expect(other_user.reload.display_name).to eq "New Name"
       end
     end
   end


### PR DESCRIPTION
- Adds `edit`/`update` actions to `Admin::UsersController` for editing a user's `display_name`, with the admin users index now linking display names to the edit page.
- Extracts the admin competition_users table into `app/views/admin/competition_users/_table.html.erb` so it can be rendered both on the competition_users index and on the new admin user edit page (scoped to that user's competitions).