### PR TITLE
Preserve password on Strava sign-in to allow multi-device sessions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,11 +58,13 @@ class User < ApplicationRecord
     end
 
     def from_omniauth(uid, auth)
-      user = where(strava_id: uid.to_i).first || new(strava_id: uid.to_i)
-
-      user.update(password: Devise.friendly_token[0, 20],
+      user = where(strava_id: uid.to_i).first_or_initialize
+      attrs = {
         strava_auth: stored_strava_auth(auth["credentials"]),
-        strava_info: auth.dig("extra", "raw_info"))
+        strava_info: auth.dig("extra", "raw_info")
+      }
+      attrs[:password] = Devise.friendly_token[0, 20] if user.new_record?
+      user.update(attrs)
       user
     end
 

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Competition, type: :model do
     end
 
     context "with future, but set current" do
-      let(:start_date) { Time.current + 1.week }
+      let(:start_date) { Time.current.next_month.beginning_of_month }
       it "sets current, unsets all others" do
         expect(competition1.reload.current).to be_truthy
         expect(competition1.display_name).to eq "MIBM 2023"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,6 +67,35 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "from_omniauth" do
+    let(:uid) { 123456 }
+    let(:auth) do
+      {
+        "credentials" => {"token" => "tok", "refresh_token" => "refresh", "expires_at" => (Time.current + 1.hour).to_i},
+        "extra" => {"raw_info" => {"username" => "new-rider", "firstname" => "New", "lastname" => "Rider"}}
+      }
+    end
+
+    it "creates a new user with a password" do
+      expect { User.from_omniauth(uid, auth) }.to change(User, :count).by(1)
+      user = User.find_by(strava_id: uid)
+      expect(user.strava_username).to eq "new-rider"
+      expect(user.encrypted_password).to be_present
+    end
+
+    context "when the user already exists" do
+      let!(:existing) { FactoryBot.create(:user, strava_id: uid) }
+
+      it "updates strava data without rotating encrypted_password" do
+        original_encrypted_password = existing.encrypted_password
+        expect { User.from_omniauth(uid, auth) }.not_to change(User, :count)
+        existing.reload
+        expect(existing.encrypted_password).to eq original_encrypted_password
+        expect(existing.strava_auth["token"]).to eq "tok"
+      end
+    end
+  end
+
   describe "after_commit" do
     let(:user) { FactoryBot.create(:user) }
     let(:start_date) { Time.current.beginning_of_month }


### PR DESCRIPTION
- `User.from_omniauth` was rotating `encrypted_password` on every Strava callback, which changes Devise's `authenticatable_salt`. Devise uses that salt to validate sessions, so any previously signed-in device was silently logged out the moment the user signed in elsewhere.
- Now the password is only generated when the user is first created; subsequent sign-ins only refresh `strava_auth` and `strava_info`, leaving existing sessions on other devices intact.