### PR TITLE
Add admin: rank column, role editing, matching count, and pagination

### DIFF
--- a/app/components/admin/current_header/component.html.erb
+++ b/app/components/admin/current_header/component.html.erb
@@ -9,7 +9,8 @@
   </div>
 
   <p class="mb-2">
-    <%= @viewing %>
+    <%= number_display(matching_count) %>
+    <%= @viewing.singularize.pluralize(matching_count) %>
 
     <% if @competition_subject.present? %>
       for competition:

--- a/app/components/admin/current_header/component.rb
+++ b/app/components/admin/current_header/component.rb
@@ -3,10 +3,11 @@
 module Admin
   module CurrentHeader
     class Component < ApplicationComponent
-      def initialize(viewing:, searchable_competitions:, s_params:, include_competition_select: false, competition_subject: nil, user_subject: nil, user_param: nil, render_period: false, render_chart: false, chart_collection: nil, time_range: nil, time_range_column: "created_at")
+      def initialize(viewing:, searchable_competitions:, s_params:, pagy:, include_competition_select: false, competition_subject: nil, user_subject: nil, user_param: nil, render_period: false, render_chart: false, chart_collection: nil, time_range: nil, time_range_column: "created_at")
         @viewing = viewing
         @include_competition_select = include_competition_select
         @s_params = s_params
+        @pagy = pagy
         @competition_subject = competition_subject
         @user_subject = user_subject
         @user_param = user_param
@@ -39,7 +40,7 @@ module Admin
       end
 
       def matching_count
-        @matching_count ||= @chart_collection&.size || 0
+        @pagy&.count || 0
       end
 
       def chart_component

--- a/app/components/admin/current_header/component.rb
+++ b/app/components/admin/current_header/component.rb
@@ -38,6 +38,10 @@ module Admin
         @render_chart && @chart_collection.present? && @time_range.present?
       end
 
+      def matching_count
+        @matching_count ||= @chart_collection&.size || 0
+      end
+
       def chart_component
         data = UI::Chart::Component.time_range_counts(collection: @chart_collection, time_range: @time_range, column: @time_range_column)
         UI::Chart::Component.new(series: [{name: @viewing, data:}], time_range: @time_range)

--- a/app/controllers/admin/competition_users_controller.rb
+++ b/app/controllers/admin/competition_users_controller.rb
@@ -6,9 +6,11 @@ module Admin
 
     def index
       @matching_competition_users = searched_competition_users
-      @competition_users = @matching_competition_users
-        .reorder("competition_users.#{sort_column} #{sort_direction}")
-        .includes(:competition, :competition_activities)
+      @pagy, @competition_users = pagy(:countish,
+        @matching_competition_users
+          .reorder("competition_users.#{sort_column} #{sort_direction}")
+          .includes(:competition, :competition_activities),
+        limit: per_page, page:)
     end
 
     def edit

--- a/app/controllers/admin/competitions_controller.rb
+++ b/app/controllers/admin/competitions_controller.rb
@@ -4,9 +4,11 @@ module Admin
 
     def index
       @matching_competitions = searched_competitions
-      @competitions = @matching_competitions
-        .reorder("competitions.#{sort_column} #{sort_direction}")
-        .includes(:competition_users)
+      @pagy, @competitions = pagy(:countish,
+        @matching_competitions
+          .reorder("competitions.#{sort_column} #{sort_direction}")
+          .includes(:competition_users),
+        limit: per_page, page:)
     end
 
     def new

--- a/app/controllers/admin/strava_requests_controller.rb
+++ b/app/controllers/admin/strava_requests_controller.rb
@@ -4,10 +4,11 @@ module Admin
 
     def index
       @matching_strava_requests = searched_strava_requests
-      @strava_requests = @matching_strava_requests
-        .reorder("strava_requests.#{sort_column} #{sort_direction}")
-        .includes(:user)
-        .limit(100)
+      @pagy, @strava_requests = pagy(:countish,
+        @matching_strava_requests
+          .reorder("strava_requests.#{sort_column} #{sort_direction}")
+          .includes(:user),
+        limit: per_page, page:)
     end
 
     private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,9 +6,11 @@ module Admin
 
     def index
       @matching_users = searched_users
-      @users = @matching_users
-        .reorder("users.#{sort_column} #{sort_direction}")
-        .includes(:competition_users)
+      @pagy, @users = pagy(:countish,
+        @matching_users
+          .reorder("users.#{sort_column} #{sort_direction}")
+          .includes(:competition_users),
+        limit: per_page, page:)
     end
 
     def edit

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -41,7 +41,7 @@ module Admin
     end
 
     def permitted_params
-      params.require(:user).permit(:display_name)
+      params.require(:user).permit(:display_name, :role)
     end
 
     def find_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
 
   self.default_earliest_time = Time.at(1714460400).freeze # 2024-4-30
 
+  rescue_from Pagy::RangeError, with: :redirect_to_last_page
+
   before_action :enable_rack_profiler
 
   before_action do
@@ -101,5 +103,9 @@ class ApplicationController < ActionController::Base
   def permitted_user_redirect_path(path = nil)
     return nil if path.blank? || path.start_with?("/")
     path
+  end
+
+  def redirect_to_last_page(exception)
+    redirect_to url_for(page: exception.pagy.last), allow_other_host: false
   end
 end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -74,6 +74,10 @@ class Competition < ApplicationRecord
     DEFAULT_ACTIVITY_TYPES # NOTE: Can be manually specified on CompetitionParticipant
   end
 
+  def included_competition_user_ids_score_ordered
+    @included_competition_user_ids_score_ordered ||= competition_users_included.score_ordered.pluck(:id)
+  end
+
   def in_period?(passed_dates_or_times)
     return false if passed_dates_or_times.blank?
     activity_dates = dates_array_from(passed_dates_or_times)

--- a/app/models/competition_user.rb
+++ b/app/models/competition_user.rb
@@ -119,6 +119,16 @@ class CompetitionUser < ApplicationRecord
     end
   end
 
+  def rank_in_competition
+    return nil unless included_in_competition
+    index = competition.included_competition_user_ids_score_ordered.index(id)
+    index && index + 1
+  end
+
+  def rider_count_in_competition
+    competition.included_competition_user_ids_score_ordered.size
+  end
+
   def everyday_rider?
     dates_before_current_date.all? { |date| activity_dates.include?(date.to_s) }
   end

--- a/app/views/admin/competition_users/_table.html.erb
+++ b/app/views/admin/competition_users/_table.html.erb
@@ -24,5 +24,9 @@
 
   table.column(label: "Activities") { |cu| number_display(cu.competition_activities.count) }
 
+  table.column(label: "Rank") do |cu|
+    "#{cu.rank_in_competition}/#{cu.rider_count_in_competition}" if cu.included_in_competition
+  end
+
   table.column(label: "Included?") { |cu| check_mark if cu.included_in_competition }
 end %>

--- a/app/views/admin/competition_users/index.html.erb
+++ b/app/views/admin/competition_users/index.html.erb
@@ -1,6 +1,8 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_competition_users, time_range: @time_range, time_range_column: @time_range_column)) %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: true, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, render_period: false, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competition_users, time_range: @time_range, time_range_column: @time_range_column)) %>
 
 <%= render partial: "admin/competition_users/table", locals: {
   competition_users: @competition_users,
   include_competition: competition_subject.blank?
 } %>
+
+<%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: sortable_params)) %>

--- a/app/views/admin/competitions/index.html.erb
+++ b/app/views/admin/competitions/index.html.erb
@@ -1,4 +1,4 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_competitions, time_range: @time_range, time_range_column: @time_range_column)) do %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject:, searchable_competitions:, render_period: false, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competitions, time_range: @time_range, time_range_column: @time_range_column)) do %>
   <%= link_to "New Competition", new_admin_competition_path, class: "twlink" %>
 <% end %>
 
@@ -44,3 +44,5 @@
     number_display(competition.competition_users_excluded.count)
   end
 end %>
+
+<%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: sortable_params)) %>

--- a/app/views/admin/strava_requests/index.html.erb
+++ b/app/views/admin/strava_requests/index.html.erb
@@ -1,4 +1,4 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject: nil, user_subject:, user_param: params[:user], searchable_competitions: nil, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_strava_requests, time_range: @time_range)) %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject: nil, user_subject:, user_param: params[:user], searchable_competitions: nil, render_period: false, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_strava_requests, time_range: @time_range)) %>
 
 <%# Local var because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>
@@ -32,3 +32,5 @@
     end
   end
 end %>
+
+<%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: sortable_params)) %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -39,6 +39,13 @@
     <div class="col">
       <%= render Form::Group::Component.new(form_builder: f, attribute: :display_name, html_options: {required: true}) %>
     </div>
+
+    <div class="col">
+      <div class="mb-4">
+        <%= f.label :role, class: Form::Group::Component::LABEL_CLASSES %>
+        <%= f.select :role, User.roles.keys.map { |r| [r.humanize, r] }, {}, class: Form::Input::Component::INPUT_CLASSES %>
+      </div>
+    </div>
   </div>
 
   <div class="form-row-btn">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject: nil, searchable_competitions: nil, render_period: false, s_params: sortable_params, render_chart: @render_chart, chart_collection: @matching_users, time_range: @time_range, time_range_column: @time_range_column)) %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject: nil, searchable_competitions: nil, render_period: false, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_users, time_range: @time_range, time_range_column: @time_range_column)) %>
 
 <%# Local var because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>
@@ -26,3 +26,5 @@
 
   table.column(sortable: "role") { |user| user.role unless user.role == "basic_user" }
 end %>
+
+<%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: sortable_params)) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,10 +1,10 @@
 {
   "ignored_warnings": [
     {
-      "fingerprint": "4278000db1e81282bca72313c1eb228fe8beb0f1dab825813c443b2eee502302",
-      "note": "Only link_to outputs are joined - all values are already HTML-safe"
+      "fingerprint": "ec7a5213f42e6a5d451998520049d937c1c7a4a448ca4507c59860b76a9146a7",
+      "note": "Admin-only controller (gated by ensure_user_admin!) — role assignment is intentional"
     }
   ],
-  "updated": "2026-04-02",
+  "updated": "2026-04-23",
   "brakeman_version": "8.0.4"
 }

--- a/spec/components/admin/current_header/component_spec.rb
+++ b/spec/components/admin/current_header/component_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Admin::CurrentHeader::Component, type: :component do
       competition_subject: nil,
       searchable_competitions: Competition.order(start_date: :desc),
       render_period: false,
-      s_params: {}
+      s_params: {},
+      pagy: Pagy::Offset.new(count: 0, limit: 25, page: 1)
     }
   end
   let(:options) { default_options }
@@ -26,18 +27,16 @@ RSpec.describe Admin::CurrentHeader::Component, type: :component do
     expect(component.css("p").first.text).to match(/0\s+Competition users\s+for all competitions/)
   end
 
-  context "with a chart_collection of two records" do
-    let!(:competition_users) { FactoryBot.create_list(:competition_user, 2) }
-    let(:options) { default_options.merge(chart_collection: CompetitionUser.all) }
+  context "with a pagy count of two" do
+    let(:options) { default_options.merge(pagy: Pagy::Offset.new(count: 2, limit: 25, page: 1)) }
 
     it "renders the count with pluralized viewing" do
       expect(component.css("p").first.text).to match(/2\s+Competition users\s+for all competitions/)
     end
   end
 
-  context "with a chart_collection of one record" do
-    let!(:competition_user) { FactoryBot.create(:competition_user) }
-    let(:options) { default_options.merge(chart_collection: CompetitionUser.all) }
+  context "with a pagy count of one" do
+    let(:options) { default_options.merge(pagy: Pagy::Offset.new(count: 1, limit: 25, page: 1)) }
 
     it "uses the singular form" do
       expect(component.css("p").first.text).to match(/1\s+Competition user\s+for all competitions/)

--- a/spec/components/admin/current_header/component_spec.rb
+++ b/spec/components/admin/current_header/component_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Admin::CurrentHeader::Component, type: :component do
   let(:default_options) do
     {
-      viewing: "competition_users",
+      viewing: "Competition users",
       include_competition_select: true,
       competition_subject: nil,
       searchable_competitions: Competition.order(start_date: :desc),
@@ -23,6 +23,25 @@ RSpec.describe Admin::CurrentHeader::Component, type: :component do
     expect(component.css("h1").text.strip).to eq "Admin Competition Users"
     expect(component.css("a").map(&:text)).to include("graph")
     expect(component.css("a[href*='render_chart=true']")).to be_present
+    expect(component.css("p").first.text).to match(/0\s+Competition users\s+for all competitions/)
+  end
+
+  context "with a chart_collection of two records" do
+    let!(:competition_users) { FactoryBot.create_list(:competition_user, 2) }
+    let(:options) { default_options.merge(chart_collection: CompetitionUser.all) }
+
+    it "renders the count with pluralized viewing" do
+      expect(component.css("p").first.text).to match(/2\s+Competition users\s+for all competitions/)
+    end
+  end
+
+  context "with a chart_collection of one record" do
+    let!(:competition_user) { FactoryBot.create(:competition_user) }
+    let(:options) { default_options.merge(chart_collection: CompetitionUser.all) }
+
+    it "uses the singular form" do
+      expect(component.css("p").first.text).to match(/1\s+Competition user\s+for all competitions/)
+    end
   end
 
   context "with a content block" do

--- a/spec/models/competition_user_spec.rb
+++ b/spec/models/competition_user_spec.rb
@@ -209,6 +209,26 @@ RSpec.describe CompetitionUser, type: :model do
     end
   end
 
+  describe "rank_in_competition" do
+    let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2024-05-01")) }
+    let!(:competition_user1) { FactoryBot.create(:competition_user, competition:, score_data: {dates: ["2024-05-01"], distance: 10_000, elevation: 0}) }
+    let!(:competition_user2) { FactoryBot.create(:competition_user, competition:, score_data: {dates: ["2024-05-01", "2024-05-02"], distance: 20_000, elevation: 0}) }
+    let!(:competition_user3) { FactoryBot.create(:competition_user, competition:, included_in_competition: false, score_data: {dates: ["2024-05-01", "2024-05-02", "2024-05-03"], distance: 50_000, elevation: 0}) }
+
+    it "returns the score-ordered rank among included users" do
+      expect(competition_user2.rank_in_competition).to eq 1
+      expect(competition_user1.rank_in_competition).to eq 2
+      expect(competition_user2.rider_count_in_competition).to eq 2
+    end
+
+    context "when not included in competition" do
+      it "returns nil for rank" do
+        expect(competition_user3.rank_in_competition).to be_nil
+        expect(competition_user3.rider_count_in_competition).to eq 2
+      end
+    end
+  end
+
   describe "scoring" do
     let(:competition) { FactoryBot.create(:competition, start_date: Time.parse("2024-05-01")) }
     let(:competition_user1) { FactoryBot.create(:competition_user, competition:) }

--- a/spec/models/competition_user_spec.rb
+++ b/spec/models/competition_user_spec.rb
@@ -215,17 +215,12 @@ RSpec.describe CompetitionUser, type: :model do
     let!(:competition_user2) { FactoryBot.create(:competition_user, competition:, score_data: {dates: ["2024-05-01", "2024-05-02"], distance: 20_000, elevation: 0}) }
     let!(:competition_user3) { FactoryBot.create(:competition_user, competition:, included_in_competition: false, score_data: {dates: ["2024-05-01", "2024-05-02", "2024-05-03"], distance: 50_000, elevation: 0}) }
 
-    it "returns the score-ordered rank among included users" do
+    it "returns the score-ordered rank among included users and nil for excluded" do
       expect(competition_user2.rank_in_competition).to eq 1
       expect(competition_user1.rank_in_competition).to eq 2
+      expect(competition_user3.rank_in_competition).to be_nil
       expect(competition_user2.rider_count_in_competition).to eq 2
-    end
-
-    context "when not included in competition" do
-      it "returns nil for rank" do
-        expect(competition_user3.rank_in_competition).to be_nil
-        expect(competition_user3.rider_count_in_competition).to eq 2
-      end
+      expect(competition_user3.rider_count_in_competition).to eq 2
     end
   end
 

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -62,13 +62,15 @@ RSpec.describe base_url, type: :request do
 
     describe "update" do
       let(:other_user) { FactoryBot.create(:user, display_name: "Old Name") }
-      let(:valid_params) { {display_name: "New Name"} }
+      let(:valid_params) { {display_name: "New Name", role: "developer"} }
 
-      it "updates display_name" do
+      it "updates display_name and role" do
         patch "#{base_url}/#{other_user.id}", params: {user: valid_params}
         expect(flash[:success]).to be_present
         expect(response).to redirect_to admin_users_path
-        expect(other_user.reload.display_name).to eq "New Name"
+        other_user.reload
+        expect(other_user.display_name).to eq "New Name"
+        expect(other_user.role).to eq "developer"
       end
     end
   end


### PR DESCRIPTION
- Adds a Rank column (rank/rider_count) to the admin competition users table, scoped to included users and ordered by score
- Adds a role select to the admin user edit page so admins can change roles
- Replaces the redundant "{Viewing} for all competitions" subtitle with "{count} {pluralized viewing} for all competitions" using `number_display` + `pluralize`
- Adds pagy pagination to admin index pages (competitions, competition_users, users, strava_requests) using the `:countish` paginator, following bike_index conventions
