### PR TITLE
Fix landing crash when Strava returns avatar placeholder path

### DIFF
--- a/app/components/admin/current_header/component.html.erb
+++ b/app/components/admin/current_header/component.html.erb
@@ -12,25 +12,24 @@
     <%= number_display(matching_count) %>
     <%= @viewing.singularize.pluralize(matching_count) %>
 
-    <% if @competition_subject.present? %>
-      for competition:
-      <strong><%= @competition_subject.display_name %></strong>
-    <% else %>
-      for all competitions
-    <% end %>
-
-    <% if @include_competition_select || @competition_subject.present? %>
+    <% if @include_competition_select %>
+      <% if @competition_subject.present? %>
+        for competition:
+        <strong><%= @competition_subject.display_name %></strong>
+      <% else %>
+        for all competitions
+      <% end %>
       <span class="less-strong">
         <em>
           &ndash; view for
-          <% if @searchable_competitions.present? && @include_competition_select %>
+          <% if @searchable_competitions.present? %>
             <%= select_tag :search_competition_id, options_for_select(@searchable_competitions.map { |s| [s.display_name, s.id] }, @competition_subject&.id), prompt: "Choose competition", class: "cursor-pointer updateOnChange mx-1", "data-updateUrl" => url_for(@s_params.merge(search_competition_id: "UpdateThis")) %>
             <% unless @competition_subject.blank? %>
               or for
             <% end %>
           <% end %>
           <% if @competition_subject.present? %>
-            <%= link_to "all competitions", url_for(@s_params.merge(search_competition_id: nil)), class: "twlink" %>
+            <%= link_to "all competitions", url_for(@s_params.merge(search_competition_id: "all")), class: "twlink" %>
           <% end %>
         </em>
       </span>

--- a/app/components/alerts/flash_messages/component.rb
+++ b/app/components/alerts/flash_messages/component.rb
@@ -9,10 +9,12 @@ module Alerts
 
       private
 
+      KIND_ALIASES = {alert: :error}.freeze
+
       def messages
         @flash.filter_map do |type, message|
           next unless message.is_a?(String)
-          kind = type.to_sym
+          kind = KIND_ALIASES[type.to_sym] || type.to_sym
           raise ArgumentError, "Unknown flash type: #{type}" unless UI::Alert::Component::KINDS.include?(kind)
           {text: message, kind:}
         end

--- a/app/components/alerts/flash_messages/component.rb
+++ b/app/components/alerts/flash_messages/component.rb
@@ -3,13 +3,13 @@
 module Alerts
   module FlashMessages
     class Component < ApplicationComponent
+      KIND_ALIASES = {alert: :error}.freeze
+
       def initialize(flash: {})
         @flash = flash
       end
 
       private
-
-      KIND_ALIASES = {alert: :error}.freeze
 
       def messages
         @flash.filter_map do |type, message|

--- a/app/components/user_dropdown/component.rb
+++ b/app/components/user_dropdown/component.rb
@@ -9,7 +9,10 @@ module UserDropdown
 
     private
 
-    def avatar_url = @current_user.strava_info&.dig("profile_medium")
+    def avatar_url
+      url = @current_user.strava_info&.dig("profile_medium")
+      url if url&.start_with?("http")
+    end
 
     def avatar_content
       if avatar_url.present?

--- a/app/controllers/admin/competition_users_controller.rb
+++ b/app/controllers/admin/competition_users_controller.rb
@@ -31,6 +31,20 @@ module Admin
       %w[updated_at created_at email username]
     end
 
+    def competition_subject
+      return @competition_subject if defined?(@competition_subject)
+
+      competition_params = params.permit(:competition_id, :search_competition_id)
+      competition_id = competition_params[:competition_id].presence || competition_params[:search_competition_id].presence
+      @competition_subject = if competition_id == "all"
+        nil
+      elsif competition_id.present?
+        Competition.friendly_find(competition_id)
+      else
+        Competition.current
+      end
+    end
+
     def searched_competition_users
       competition_users = CompetitionUser
       if competition_subject.present?

--- a/app/helpers/application_component_helper.rb
+++ b/app/helpers/application_component_helper.rb
@@ -15,4 +15,9 @@ module ApplicationComponentHelper
   def cross_mark
     "&#x274C;".html_safe
   end
+
+  def strava_link(user)
+    return nil if user.strava_id.blank?
+    link_to(user.strava_username.presence || user.strava_id, user.strava_user_url, target: "_blank", class: "twlink")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ApplicationRecord
         strava_auth: stored_strava_auth(auth["credentials"]),
         strava_info: auth.dig("extra", "raw_info")
       }
-      attrs[:password] = Devise.friendly_token[0, 20] if user.new_record?
+      attrs[:password] = Devise.friendly_token[0, 20] if user.encrypted_password.blank?
       user.update(attrs)
       user
     end

--- a/app/views/admin/competition_users/edit.html.erb
+++ b/app/views/admin/competition_users/edit.html.erb
@@ -28,9 +28,9 @@
   <%= render(UI::DefinitionList::Component.new) do |list| %>
     <% list.with_entry(label: "User") { user.display_name } %>
 
-    <% if user.strava_username.present? %>
+    <% if user.strava_id.present? %>
       <% list.with_entry(label: "Strava") do %>
-        <%= link_to user.strava_username, user.strava_user_url, target: "_blank", class: "twlink" %>
+        <%= link_to user.strava_username.presence || user.strava_id, user.strava_user_url, target: "_blank", class: "twlink" %>
       <% end %>
     <% end %>
 

--- a/app/views/admin/competition_users/edit.html.erb
+++ b/app/views/admin/competition_users/edit.html.erb
@@ -29,9 +29,7 @@
     <% list.with_entry(label: "User") { user.display_name } %>
 
     <% if user.strava_id.present? %>
-      <% list.with_entry(label: "Strava") do %>
-        <%= link_to user.strava_username.presence || user.strava_id, user.strava_user_url, target: "_blank", class: "twlink" %>
-      <% end %>
+      <% list.with_entry(label: "Strava") { strava_link(user) } %>
     <% end %>
 
     <% list.with_entry(label: "Role") { user.role } %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -21,9 +21,7 @@
 
   <%= render(UI::DefinitionList::Component.new) do |list| %>
     <% if @user.strava_id.present? %>
-      <% list.with_entry(label: "Strava") do %>
-        <%= link_to @user.strava_username.presence || @user.strava_id, @user.strava_user_url, target: "_blank", class: "twlink" %>
-      <% end %>
+      <% list.with_entry(label: "Strava") { strava_link(@user) } %>
     <% end %>
 
     <% list.with_entry(label: "Competitions") do %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -20,9 +20,9 @@
   <% end %>
 
   <%= render(UI::DefinitionList::Component.new) do |list| %>
-    <% if @user.strava_username.present? %>
+    <% if @user.strava_id.present? %>
       <% list.with_entry(label: "Strava") do %>
-        <%= link_to @user.strava_username, @user.strava_user_url, target: "_blank", class: "twlink" %>
+        <%= link_to @user.strava_username.presence || @user.strava_id, @user.strava_user_url, target: "_blank", class: "twlink" %>
       <% end %>
     <% end %>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -12,11 +12,7 @@
     link_to(user.display_name, edit_admin_user_path(user), class: "twlink")
   end
 
-  table.column(sortable: "strava_username", label: "Strava") do |user|
-    if user.strava_id.present?
-      link_to(user.strava_username.presence || user.strava_id, user.strava_user_url, target: "_blank", class: "twlink")
-    end
-  end
+  table.column(sortable: "strava_username", label: "Strava") { |user| strava_link(user) }
 
   table.column(sortable: "last_sign_in_at", label: "Last sign in") do |user|
     if user.last_sign_in_at.present?

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -12,6 +12,12 @@
     link_to(user.display_name, edit_admin_user_path(user), class: "twlink")
   end
 
+  table.column(sortable: "strava_username", label: "Strava") do |user|
+    if user.strava_id.present?
+      link_to(user.strava_username.presence || user.strava_id, user.strava_user_url, target: "_blank", class: "twlink")
+    end
+  end
+
   table.column(sortable: "last_sign_in_at", label: "Last sign in") do |user|
     if user.last_sign_in_at.present?
       render(UI::Time::Component.new(time: user.last_sign_in_at))

--- a/spec/components/admin/current_header/component_spec.rb
+++ b/spec/components/admin/current_header/component_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe Admin::CurrentHeader::Component, type: :component do
     it "still renders the graph toggle" do
       expect(component.css("a").map(&:text)).to include("graph")
     end
+
+    it "does not render the competition filter line" do
+      expect(component.css("p").first.text).not_to include("for all competitions")
+      expect(component.css("p").first.text).not_to include("view for")
+    end
   end
 
   context "with render_chart: true and chart_collection" do

--- a/spec/components/alerts/flash_messages/component_spec.rb
+++ b/spec/components/alerts/flash_messages/component_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Alerts::FlashMessages::Component, type: :component do
     end
   end
 
+  context "alert (Devise-style)" do
+    let(:flash) { {alert: "Sign-in failed"} }
+
+    it "renders as an error alert" do
+      expect(component).to have_content("Sign-in failed")
+      expect(component).to have_css('[role="alert"].text-red-800')
+    end
+  end
+
   context "unknown flash type" do
     let(:flash) { {bogus: "wat"} }
 

--- a/spec/components/user_dropdown/component_spec.rb
+++ b/spec/components/user_dropdown/component_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserDropdown::Component, type: :component do
+  let(:user) { FactoryBot.build_stubbed(:user, display_name: "Rider", strava_info:) }
+  let(:strava_info) { nil }
+  let(:rendered) { render_inline(described_class.new(current_user: user)) }
+
+  context "with no strava_info" do
+    it "renders initials in place of an avatar image" do
+      expect(rendered.css("img")).to be_empty
+      expect(rendered.text).to include "R"
+    end
+  end
+
+  context "when profile_medium is the Strava placeholder path" do
+    let(:strava_info) { {"profile_medium" => "avatar/athlete/medium.png"} }
+
+    it "renders initials instead of resolving the placeholder as a local asset" do
+      expect(rendered.css("img")).to be_empty
+    end
+  end
+
+  context "when profile_medium is a full url" do
+    let(:strava_info) { {"profile_medium" => "https://example.com/profile.jpg"} }
+
+    it "renders the profile image" do
+      expect(rendered.css("img").attr("src").value).to eq "https://example.com/profile.jpg"
+    end
+  end
+end

--- a/spec/requests/admin/competition_users_request_spec.rb
+++ b/spec/requests/admin/competition_users_request_spec.rb
@@ -41,29 +41,46 @@ RSpec.describe base_url, type: :request do
         end
       end
       context "with things" do
-        let!(:competition_user1) { FactoryBot.create(:competition_user) }
-        let!(:competition_user2) { FactoryBot.create(:competition_user) }
-        let(:competition1) { competition_user1.competition }
-        it "renders" do
+        let!(:competition_user1) { FactoryBot.create(:competition_user, competition: competition1) }
+        let!(:competition_user2) { FactoryBot.create(:competition_user, competition: competition2) }
+        let(:competition1) { FactoryBot.create(:competition, start_date: Date.parse("2024-05-01")) }
+        let(:competition2) { FactoryBot.create(:competition) }
+
+        it "defaults to the current competition" do
           expect(Competition.count).to eq 2
+          expect(Competition.current).to eq competition2
+
           get base_url
           expect(response.code).to eq "200"
           expect(response).to render_template("admin/competition_users/index")
-          expect(assigns(:competition_users).pluck(:id)).to match_array([competition_user1.id, competition_user2.id])
+          expect(assigns(:competition_subject)).to eq competition2
+          expect(assigns(:competition_users).pluck(:id)).to eq([competition_user2.id])
+        end
 
+        it "filters by search_competition_id when provided" do
           get "#{base_url}?search_competition_id=#{competition1.id}"
           expect(response.code).to eq "200"
-          expect(response).to render_template("admin/competition_users/index")
-          expect(assigns(:competition_subject).id).to eq competition1.id
+          expect(assigns(:competition_subject)).to eq competition1
           expect(assigns(:competition_users).pluck(:id)).to eq([competition_user1.id])
+        end
 
+        it "shows all competitions when search_competition_id=all" do
+          get "#{base_url}?search_competition_id=all"
+          expect(response.code).to eq "200"
+          expect(assigns(:competition_subject)).to be_nil
+          expect(assigns(:competition_users).pluck(:id)).to match_array([competition_user1.id, competition_user2.id])
+        end
+
+        it "filters by user within the default current competition" do
           get "#{base_url}?user=#{competition_user2.user.slug}"
           expect(response.code).to eq "200"
           expect(assigns(:user_subject).id).to eq competition_user2.user_id
           expect(assigns(:competition_users).pluck(:id)).to eq([competition_user2.id])
           expect(response.body).to include("for user:")
           expect(response.body).to include(competition_user2.user.display_name)
+        end
 
+        it "renders missing-user message for unknown slugs" do
           get "#{base_url}?user=unknown-slug"
           expect(response.code).to eq "200"
           expect(assigns(:user_subject)).to be_nil

--- a/spec/requests/authentication_request_spec.rb
+++ b/spec/requests/authentication_request_spec.rb
@@ -153,5 +153,19 @@ RSpec.describe "Authentication", type: :request do
         expect(signup_and_get_user(signup_unit: "imperial").unit).to eq "imperial"
       end
     end
+
+    context "with an existing user that has no encrypted_password" do
+      let!(:user) do
+        FactoryBot.create(:user, strava_id: "2430215").tap do |u|
+          u.update_columns(encrypted_password: "")
+        end
+      end
+
+      it "sets a password and signs the user in without raising" do
+        expect { post path }.not_to change(User, :count)
+        expect(user.reload.encrypted_password).to be_present
+        expect(user.last_sign_in_at).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes two Honeybadger crashes and tidies up a few admin views in passing.

- **Landing page**: `UserDropdown::Component` was passing Strava's `profile_medium` placeholder string `avatar/athlete/medium.png` directly to `image_tag`, making Propshaft 500 the page for athletes with no profile photo. Treat `profile_medium` as a URL only when it starts with `http`.
- **Strava sign-in**: `User.from_omniauth` only assigned a password for brand-new records, so existing users with a blank `encrypted_password` raised `authenticatable_salt returned nil` from rememberable. Set the password whenever `encrypted_password.blank?`, backfilling legacy users on next sign-in.
- **Flash layout**: Devise's failure handler sets `flash[:alert]`, which `Alerts::FlashMessages::Component` rejected with `ArgumentError: Unknown flash type: alert`. Alias `:alert` → `:error`.
- **Admin Strava link**: rendered whenever `strava_id` is present (falling back to `strava_id` for the link text) instead of requiring a Strava username. New `strava_link` helper used in both edit pages and the admin users table, which gains a Strava column.
- **Admin competition users**: defaults to the current competition; `search_competition_id=all` is the explicit sentinel for "all competitions". The shared `current_header` competition filter line is now gated on `include_competition_select`, so it no longer shows on `/admin/users`, `/admin/strava_requests`, or `/admin/competitions`.
