### PR TITLE
Localize footer time, opt-in `?days=` URL, integration-testing skill

### DIFF
--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: integration-testing
+description: >-
+  May is Bike Month integration spec conventions — these are full
+  browser specs (`type: :system, :js`) under `spec/integration/`, and
+  every example pays a Selenium boot cost. Bias toward fewer, denser
+  examples that walk through state via clicks; prefer named-button
+  matchers over CSS selectors or `execute_script`. Trigger when writing
+  or modifying any spec under `spec/integration/`, or any `*_spec.rb`
+  with `:js` or `type: :system`. Read alongside the `rspec-testing`
+  skill, which covers the project's general `context`/`let` style.
+---
+
+# Integration testing in May is Bike Month
+
+Integration specs live under `spec/integration/` and run as full browser specs (`type: :system, :js`), driven by Capybara/Selenium. They boot a real Chrome session per example, so they are **expensive**. Optimize for fewer, denser examples and high-level Capybara helpers.
+
+The general `context`/`let` style and "what to test" rules are in the [`rspec-testing`](../rspec-testing/SKILL.md) skill — the rules below extend it for the system-spec case.
+
+## One `it` per setup; many assertions per `it`
+
+Unit specs prefer one assertion per example. **Integration specs prefer the opposite**: when several assertions share the same fixture and the same initial `visit`, fold them into one example that walks through state transitions (click → assert → click → assert).
+
+Use `context` only when the *setup* differs — a different `let!`, a different page, a different feature flag. Don't split a single user flow across sibling `it` blocks just because each step has its own assertion.
+
+**Combine even "independent scenarios" if their setup matches.** It is tempting to leave separate `it`s for things that feel like different concerns ("button-state test", "morph-capture test", "URL persistence test", "footer localization test"). Don't. If they share fixtures and the same initial `visit`, fold them all into one example and use a known reset action (`click_button("Hide all activities")`, navigating away, etc.) between phases. A long, sectioned-with-comments example pays one Selenium boot; four short examples pay four. Failure attribution is fine — the failed line number tells you exactly which phase broke.
+
+**Before writing a new `describe`/`context`/`it`, read the existing file.** When adding coverage to a spec, look for a block whose setup already gets you most of the way there and append clicks/assertions to it. Only add a new block when the setup genuinely differs — otherwise you're paying a fresh Selenium boot for something a few extra lines in an existing example would have covered.
+
+### Good
+
+```ruby
+it "hides activities by default and toggles via Show/Hide all and per-user buttons" do
+  expect(activity_containers.size).to eq 2
+  expect(activity_containers).to all(satisfy { |c| !visible?(c) })
+
+  click_button("Show all activities")
+
+  expect(activity_containers).to all(satisfy { |c| visible?(c) })
+  expect(find_button("Show all activities")["aria-pressed"]).to eq "true"
+
+  click_button("Hide all activities")
+
+  expect(activity_containers).to all(satisfy { |c| !visible?(c) })
+
+  click_button("Alice")
+
+  expect(visible?(container_for(alice))).to be true
+  expect(visible?(container_for(bob))).to be false
+end
+```
+
+### Bad
+
+```ruby
+# Three browser sessions for what's effectively one user flow.
+it "shows activities when Show all is clicked" do
+  click_button("Show all activities")
+  expect(activity_containers).to all(satisfy { |c| visible?(c) })
+end
+
+it "hides them when Hide all is clicked" do
+  click_button("Show all activities")
+  click_button("Hide all activities")
+  expect(activity_containers).to all(satisfy { |c| !visible?(c) })
+end
+
+it "toggles per-user when a user button is clicked" do
+  click_button("Alice")
+  expect(visible?(container_for(alice))).to be true
+end
+```
+
+## Navigate by clicking, not re-visiting
+
+After the initial `visit` in `before`, prefer **clicking** to get to the next state. Re-visiting bypasses the very thing system specs exist to verify (client-side state, JS handlers, history, ARIA wiring).
+
+Re-visit only when you specifically want to verify **URL persistence / reload behavior** — and make that intent explicit (`visit page.current_url` with a comment, or a context named "after reload").
+
+```ruby
+# Good — drive the flow with clicks
+visit root_path
+click_button("Show all activities")
+click_link("Alice")
+
+# Good — explicit reload to verify URL persistence
+visit page.current_url
+
+# Bad — re-rendering that should have been a click
+visit "#{root_path}?show_all=1"
+```
+
+## Prefer named matchers over CSS selectors and JS
+
+Capybara's high-level helpers find elements by visible role + text. They are more readable, more accessible (they only see what a real user can interact with), and less brittle than scraping selectors. Reach for low-level tools only when the high-level ones can't express what you need.
+
+Order of preference:
+
+1. **Named-element helpers**: `click_button("Show all activities")`, `click_link("Alice")`, `find_button(...)`, `have_button(...)`.
+2. **Role-scoped Capybara finders**: `find(:button, "...")`, `within(:section, "Leaderboard") { ... }`.
+3. **ARIA / data attributes** when there is no visible text: `find('[aria-label="..."]')`, `find('[data-testid="..."]')`.
+4. **CSS selectors** as a last resort.
+5. **`page.execute_script`** only when the browser fundamentally cannot otherwise do what the test needs (synthesizing custom events, etc. — see below).
+
+If a button has no visible text (icon-only, etc.), add an `aria-label` to the component rather than scraping a selector in the test.
+
+### Good
+
+```ruby
+click_button("Show all activities")
+expect(find_button("Show all activities")["aria-pressed"]).to eq "true"
+expect(page).to have_button("Hide all activities")
+```
+
+### Bad
+
+```ruby
+find('[data-action="click->punch#showAll"]').click
+expect(page).to have_css('button[aria-pressed="true"]')
+page.execute_script("document.querySelector('.show-all-btn').click()")
+```
+
+## ActionCable broadcasts: do the real thing
+
+The project's `:test` cable adapter inherits from `:async`, so broadcasts in the test process do round-trip to the browser. **Don't synthesize `turbo:morph-element` events with `execute_script` to fake an ActionCable refresh** — call the real broadcaster (`Component.broadcast_replace_to`, `broadcast_refresh_current!`, etc.) and let Capybara wait for the morphed DOM.
+
+Make a small helper that prepares the data, broadcasts, and waits for an unambiguous post-morph element:
+
+```ruby
+def morph_in_punch(user:, date_string:)
+  competition_user = CompetitionUser.find_by!(user:, competition:)
+  FactoryBot.create(:competition_activity, competition_user:,
+    distance_meters: 16_093, start_at: Time.parse("#{date_string}T15:00:00Z"))
+  Leaderboard::PunchcardWrapper::Component.broadcast_refresh_current!
+  expect(page).to have_css(punch_selector(user_slug: user.slug, date_string:), wait: 5)
+end
+```
+
+The trailing `expect(...).to have_css(..., wait: 5)` is the synchronization barrier — the test only proceeds once the morph has actually rendered.
+
+## When `execute_script` is genuinely needed
+
+Some browser events can't be produced by a real user action — `popstate`, certain keyboard events, etc. In those cases:
+
+- Keep the script as small as possible.
+- Add a comment explaining *why* JS is needed instead of a click.
+- Pass values via `arguments[N]` rather than interpolating them into the script string.
+
+If you find yourself reaching for `execute_script`, double-check whether a real user action (real broadcast, real button click, real `visit page.current_url` for reload) would do the same thing — most of the time it will.
+
+## Other conventions
+
+- File the spec at `spec/integration/<feature>/<scenario>_spec.rb`.
+- Top-level description is a string (`describe "Landing page"`), not a class.
+- Always include `:js, type: :system`.
+- When the spec depends on the current date/time, freeze it with `around { |ex| travel_to(Time.parse("...")) { ex.run } }`.
+- Define a few small DSL-style helpers in the file (`def container_for(user)`, `def punch_selector(...)`) when they make assertions readable. Don't reach for `page.execute_script` to replace what a helper method could do in Ruby.

--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 
 # Integration testing in May is Bike Month
 
-Integration specs live under `spec/integration/` and run as full browser specs (`type: :system, :js`), driven by Capybara/Selenium. They boot a real Chrome session per example, so they are **expensive**. Optimize for fewer, denser examples and high-level Capybara helpers.
+Browser specs (`type: :system, :js`) live in two places: feature flows under `spec/integration/` and component-level interaction specs at `spec/components/**/*_system_spec.rb`. Both run full Chrome sessions via Capybara/Selenium and pay a real Selenium boot cost per example, so the same conventions apply to both: optimize for fewer, denser examples and high-level Capybara helpers.
 
 The general `context`/`let` style and "what to test" rules are in the [`rspec-testing`](../rspec-testing/SKILL.md) skill — the rules below extend it for the system-spec case.
 
@@ -72,21 +72,13 @@ it "toggles per-user when a user button is clicked" do
 end
 ```
 
-## Choose a clean reset between phases
+## Carry state forward, don't reset between phases
 
-When you fold multiple scenarios into one example, you need a way to return to a known state between phases — otherwise state from phase A leaks into phase B and assertions become brittle. Pick the lightest action that restores the precondition the next phase expects.
+You know what state the page is in after each click — write the next assertion against that state. Don't `click_button("Hide all activities")` between phases just to get a clean slate; resets cost a click (often two — clear, then re-establish), obscure what's actually happening, and tempt you to think of each phase as an isolated scenario rather than as one continuous user flow.
 
-**Good resets** are idempotent user actions that clear in-memory state without mutating fixtures:
-- `click_button("Hide all activities")` — clears every press and resets selectedDays in one click.
-- `click_button("Close")` / pressing Escape — closes a modal back to the closed state.
-- `visit page.current_url` — full reload, when you specifically need to verify URL persistence (state survives the reload, not just the test).
+If a carried-over state makes the next assertion awkward, that's information: usually you can reorder or rephrase phases so the previous phase's end state is exactly what the next phase needs to start from. Treat the example as a flow with state advancing through it, not a sequence of independent scenarios each demanding a pristine baseline.
 
-**Bad resets** silently rewrite the world the rest of the test depends on:
-- Creating or destroying fixture records mid-test. The next phase's assertions (and your mental model) assumed the original `let!` data; mutating it makes failures hard to diagnose.
-- Navigating away and back to clear UI state when a button click would do — a navigation also tears down ActionCable subscriptions and any in-memory captured intent your spec might have set up.
-- Direct DOM manipulation via `execute_script` to "undo" a click — not something a real user could do, so any cleanup you skip will surface as flakes once the test runs in slightly different conditions.
-
-If the only reset that works requires touching fixtures, that's a signal the next phase belongs in its own example with its own setup.
+`visit page.current_url` is a reload, not a reset — use it specifically to verify URL persistence across a fresh page load. Otherwise, prefer letting state flow.
 
 ## Navigate by clicking, not re-visiting
 
@@ -151,7 +143,5 @@ CI builds `app/assets/builds/tailwind.css` automatically; your local sandbox doe
 
 ## Other conventions
 
-- File the spec at `spec/integration/<feature>/<scenario>_spec.rb`.
 - Always include `:js, type: :system`.
-- When the spec depends on the current date/time, freeze it with `around { |ex| travel_to(Time.parse("...")) { ex.run } }`.
 - Define a few small DSL-style helpers in the file (`def container_for(user)`, `def punch_selector(...)`) when they make assertions readable. Don't reach for `page.execute_script` to replace what a helper method could do in Ruby.

--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: integration-testing
 description: >-
-  May is Bike Month integration spec conventions — these are full
-  browser specs (`type: :system, :js`) under `spec/integration/`, and
-  every example pays a Selenium boot cost. Bias toward fewer, denser
-  examples that walk through state via clicks; prefer named-button
-  matchers over CSS selectors or `execute_script`. Trigger when writing
-  or modifying any spec under `spec/integration/`, or any `*_spec.rb`
-  with `:js` or `type: :system`. Read alongside the `rspec-testing`
-  skill, which covers the project's general `context`/`let` style.
+  May is Bike Month conventions for browser specs (`type: :system, :js`)
+  — every example pays a Selenium boot cost, so bias hard toward fewer,
+  denser examples that walk through state via clicks, prefer
+  named-element matchers over CSS selectors or `execute_script`, and
+  combine same-setup work into one `it` even when scenarios feel
+  independent. **Consult this skill any time you create or modify a
+  `:js, type: :system` spec** — that includes everything under
+  `spec/integration/` AND component system specs at
+  `spec/components/**/*_system_spec.rb`; the rules apply equally to
+  both. Read alongside the `rspec-testing` skill for the project's
+  general `context`/`let` style.
 ---
 
 # Integration testing in May is Bike Month
@@ -23,9 +26,7 @@ Unit specs prefer one assertion per example. **Integration specs prefer the oppo
 
 Use `context` only when the *setup* differs — a different `let!`, a different page, a different feature flag. Don't split a single user flow across sibling `it` blocks just because each step has its own assertion.
 
-**Combine even "independent scenarios" if their setup matches.** It is tempting to leave separate `it`s for things that feel like different concerns ("button-state test", "morph-capture test", "URL persistence test", "footer localization test"). Don't. If they share fixtures and the same initial `visit`, fold them all into one example and use a known reset action (`click_button("Hide all activities")`, navigating away, etc.) between phases. A long, sectioned-with-comments example pays one Selenium boot; four short examples pay four. Failure attribution is fine — the failed line number tells you exactly which phase broke.
-
-**Before writing a new `describe`/`context`/`it`, read the existing file.** When adding coverage to a spec, look for a block whose setup already gets you most of the way there and append clicks/assertions to it. Only add a new block when the setup genuinely differs — otherwise you're paying a fresh Selenium boot for something a few extra lines in an existing example would have covered.
+**Combine same-setup work, even when scenarios feel independent.** Before writing a new `describe`/`context`/`it`, read the existing file and find an example whose fixtures and initial `visit` match what you need — then append your clicks/assertions to it. It's tempting to leave a separate `it` for things that feel like different concerns ("button-state test", "morph-capture test", "URL persistence test", "footer localization test"). Don't. A long, sectioned-with-comments example pays one Selenium boot; four short examples pay four. Failure attribution is fine — the failed line number tells you exactly which phase broke. Only add a new block when the setup genuinely differs.
 
 ### Good
 
@@ -70,6 +71,22 @@ it "toggles per-user when a user button is clicked" do
   expect(visible?(container_for(alice))).to be true
 end
 ```
+
+## Choose a clean reset between phases
+
+When you fold multiple scenarios into one example, you need a way to return to a known state between phases — otherwise state from phase A leaks into phase B and assertions become brittle. Pick the lightest action that restores the precondition the next phase expects.
+
+**Good resets** are idempotent user actions that clear in-memory state without mutating fixtures:
+- `click_button("Hide all activities")` — clears every press and resets selectedDays in one click.
+- `click_button("Close")` / pressing Escape — closes a modal back to the closed state.
+- `visit page.current_url` — full reload, when you specifically need to verify URL persistence (state survives the reload, not just the test).
+
+**Bad resets** silently rewrite the world the rest of the test depends on:
+- Creating or destroying fixture records mid-test. The next phase's assertions (and your mental model) assumed the original `let!` data; mutating it makes failures hard to diagnose.
+- Navigating away and back to clear UI state when a button click would do — a navigation also tears down ActionCable subscriptions and any in-memory captured intent your spec might have set up.
+- Direct DOM manipulation via `execute_script` to "undo" a click — not something a real user could do, so any cleanup you skip will surface as flakes once the test runs in slightly different conditions.
+
+If the only reset that works requires touching fixtures, that's a signal the next phase belongs in its own example with its own setup.
 
 ## Navigate by clicking, not re-visiting
 
@@ -122,36 +139,19 @@ page.execute_script("document.querySelector('.show-all-btn').click()")
 
 ## ActionCable broadcasts: do the real thing
 
-The project's `:test` cable adapter inherits from `:async`, so broadcasts in the test process do round-trip to the browser. **Don't synthesize `turbo:morph-element` events with `execute_script` to fake an ActionCable refresh** — call the real broadcaster (`Component.broadcast_replace_to`, `broadcast_refresh_current!`, etc.) and let Capybara wait for the morphed DOM.
+The project's `:test` cable adapter inherits from `:async`, so broadcasts in the test process do round-trip to the browser. **Don't synthesize `turbo:morph-element` events with `execute_script` to fake an ActionCable refresh** — call the real broadcaster (`Component.broadcast_replace_to`, `broadcast_refresh_current!`, etc.) and let Capybara's wait do the synchronization.
 
-Make a small helper that prepares the data, broadcasts, and waits for an unambiguous post-morph element:
+The pattern is: prepare the data the broadcast will render → call the real broadcaster → assert on an unambiguous post-morph element with a `wait:` (e.g. `expect(page).to have_css(some_new_selector, wait: 5)`). The trailing wait is the synchronization barrier — the test proceeds only once the morph has actually rendered.
 
-```ruby
-def morph_in_punch(user:, date_string:)
-  competition_user = CompetitionUser.find_by!(user:, competition:)
-  FactoryBot.create(:competition_activity, competition_user:,
-    distance_meters: 16_093, start_at: Time.parse("#{date_string}T15:00:00Z"))
-  Leaderboard::PunchcardWrapper::Component.broadcast_refresh_current!
-  expect(page).to have_css(punch_selector(user_slug: user.slug, date_string:), wait: 5)
-end
-```
+## Build Tailwind before running system specs
 
-The trailing `expect(...).to have_css(..., wait: 5)` is the synchronization barrier — the test only proceeds once the morph has actually rendered.
+CI builds `app/assets/builds/tailwind.css` automatically; your local sandbox does not. Without it, Tailwind utility classes (most importantly `hidden` → `display: none`) silently don't apply, and assertions like `expect(tooltip).not_to be_visible` fail in confusing ways that look like flakes but aren't.
 
-## When `execute_script` is genuinely needed
-
-Some browser events can't be produced by a real user action — `popstate`, certain keyboard events, etc. In those cases:
-
-- Keep the script as small as possible.
-- Add a comment explaining *why* JS is needed instead of a click.
-- Pass values via `arguments[N]` rather than interpolating them into the script string.
-
-If you find yourself reaching for `execute_script`, double-check whether a real user action (real broadcast, real button click, real `visit page.current_url` for reload) would do the same thing — most of the time it will.
+**Before running any `:js, type: :system` spec locally, run `bin/rails tailwindcss:build`** (or have `bin/dev` running, which watches and rebuilds). If a system spec is failing on visibility/styling assertions, check `app/assets/builds/tailwind.css` exists and is recent before assuming the test or component is broken.
 
 ## Other conventions
 
 - File the spec at `spec/integration/<feature>/<scenario>_spec.rb`.
-- Top-level description is a string (`describe "Landing page"`), not a class.
 - Always include `:js, type: :system`.
 - When the spec depends on the current date/time, freeze it with `around { |ex| travel_to(Time.parse("...")) { ex.run } }`.
 - Define a few small DSL-style helpers in the file (`def container_for(user)`, `def punch_selector(...)`) when they make assertions readable. Don't reach for `page.execute_script` to replace what a helper method could do in Ruby.

--- a/agents.md
+++ b/agents.md
@@ -2,6 +2,8 @@
 
 This is a Rails app to track the score and generate the leaderboard for the May is Bike Month group.
 
+Be brief
+
 # Development
 
 Start the dev server with `bin/dev`
@@ -24,76 +26,18 @@ Ruby is formatted with the standard gem. Run `bin/lint` to automatically format 
 
 ## Testing
 
-This project uses Rspec for tests. All business logic should be tested.
-
-- Tests should either: help make the code correct now or prevent bugs in the future. Don't add tests that don't do one of those things.
-- Use request specs, not controller specs. Everything making the same request should be in a single test
-- Avoid testing private methods
-- Avoid mocking objects
-  - If making external requests, use VCR. Don't manually write VCR cassettes, record them by running the tests.
-- Use `context` and `let` to isolate what varies between examples.
-  - Each `it` block should live in a `context` that names the condition, with `let` overrides for only what differs in that case. Avoid repeating setup across sibling `it` blocks.
-
-**Good:**
-```ruby
-describe "display_name" do
-  let(:user) { User.new(email: "test@example.com", name:) }
-  let(:name) { nil }
-
-  it "returns email prefix when name is blank" do
-    expect(user.display_name).to eq "test"
-  end
-
-  context "when name is present" do
-    let(:name) { "Test User" }
-
-    it "returns name" do
-      expect(user.display_name).to eq "Test User"
-    end
-  end
-end
-```
-
-**Bad:**
-```ruby
-it "returns display_name" do
-  user = FactoryBot.create(:user, email: "test@example.com", name: "Test User")
-  expect(user.display_name).to eq "Test User"
-end
-it "returns email prefix when name is blank" do
-  user = FactoryBot.create(:user, email: "test@example.com")
-  allow(user).to receive(:name) { nil }
-  expect(user.display_name).to eq "test"
-end
-```
-
-### Running Tests
-
-Run tests with rspec:
-
-```bash
-bundle exec rspec
-# Or, to run just specific tests
-bundle exec rspec {FILE OR FOLDER}
-```
+Uses RSpec. All business logic should be tested. The `rspec-testing` skill covers project-specific style (`context`+`let`, request specs over controller specs, avoiding mocks).
 
 ## Frontend Development
 
-This project uses Stimulus.js for JavaScript interactivity and Tailwind CSS for styling. There are scss styles and coffeescript files, but they are deprecated.
+Uses Stimulus.js for JavaScript and Tailwind CSS for styling. The `bin/dev` command handles Tailwind and JS builds.
 
-The `bin/dev` command handles building and updating tailwind and JS.
+The `frontend-conventions` skill covers the `twinput`/`twlabel`/`twlink` classes, the `number_display` helper, the `UI::Time::Component`, and ViewComponent rules.
 
-- basic links should use the `twlink` class
+## Pull requests
 
-This project also uses the ViewComponent gem to render components.
-
-- Prefer view components to partials
-- Generate a new view component with `rails generate component ComponentName argument1 argument2`
-- View components must initialize with keyword arguments
-- In view components, prefer instance variables to attr_accessor
-- In ViewComponent templates, use `helpers.` prefix for view helpers (e.g. `helpers.time_ago_in_words`).
-  - You don't need to prefix paths (e.g. do `new_bike_path` NOT `helpers.new_bike_path`)
-- Always use `UI::Time::Component` to display time
+- When creating a PR, run the `/pr` workflow rather than calling `gh pr create` directly — `/pr` detects frontend diffs, captures desktop+mobile screenshots, and embeds them in the PR body.
+- To attach a local image (screenshot, .png/.jpg, CleanShot capture) to an existing GitHub PR, the `gh` CLI **cannot upload images** — use the `github-upload-image-to-pr` skill, which drives a real browser to GitHub's user-attachments uploader.
 
 # Initial setup
 

--- a/app/components/ui/alert/component.rb
+++ b/app/components/ui/alert/component.rb
@@ -28,13 +28,13 @@ module UI
       def color_classes
         case @kind
         when :notice
-          "#{text_color_classes} bg-purple-0 dark:bg-purple-800 border-purple-200 dark:border-purple-700"
+          "#{text_color_classes} bg-purple-0 dark:bg-purple-950 border-purple-200 dark:border-purple-700"
         when :error
-          "#{text_color_classes} bg-red-50 dark:bg-purple-800 border-red-300 dark:border-red-800"
+          "#{text_color_classes} bg-red-50 dark:bg-red-950 border-red-300 dark:border-red-800"
         when :warning
-          "#{text_color_classes} bg-yellow-50 dark:bg-purple-800 border-yellow-300 dark:border-yellow-800"
+          "#{text_color_classes} bg-yellow-50 dark:bg-yellow-950 border-yellow-300 dark:border-yellow-800"
         when :success
-          "#{text_color_classes} bg-green-50 dark:bg-purple-800 border-green-300 dark:border-green-800"
+          "#{text_color_classes} bg-green-50 dark:bg-green-950 border-green-300 dark:border-green-800"
         end
       end
 
@@ -49,13 +49,13 @@ module UI
       def dismissable_color_classes
         case @kind
         when :notice
-          "bg-purple-0 focus:ring-purple-300 hover:bg-purple-100 dark:bg-purple-800 dark:hover:bg-purple-700"
+          "bg-purple-0 focus:ring-purple-300 hover:bg-purple-100 dark:bg-purple-950 dark:hover:bg-purple-900"
         when :error
-          "bg-red-50 focus:ring-red-400 hover:bg-red-200 dark:bg-purple-800 dark:hover:bg-purple-700"
+          "bg-red-50 focus:ring-red-400 hover:bg-red-200 dark:bg-red-950 dark:hover:bg-red-900"
         when :warning
-          "bg-yellow-50 focus:ring-yellow-400 hover:bg-yellow-200 dark:bg-purple-800 dark:hover:bg-purple-700"
+          "bg-yellow-50 focus:ring-yellow-400 hover:bg-yellow-200 dark:bg-yellow-950 dark:hover:bg-yellow-900"
         when :success
-          "bg-green-50 focus:ring-green-400 hover:bg-green-200 dark:bg-purple-800 dark:hover:bg-purple-700"
+          "bg-green-50 focus:ring-green-400 hover:bg-green-200 dark:bg-green-950 dark:hover:bg-green-900"
         end
       end
     end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -13,14 +13,14 @@ module UI
 
       COLORS = {
         primary: "text-white bg-purple-500 border border-purple-500 hover:bg-purple-600 active:bg-purple-700 focus:ring-purple-400/40 dark:bg-purple-400 dark:border-purple-400 dark:hover:bg-purple-500 dark:active:bg-purple-600",
-        secondary: "text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 hover:border-gray-400 active:bg-gray-100 focus:ring-purple-400/40 dark:text-gray-200 dark:bg-gray-800 dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-500 dark:active:bg-gray-600",
+        secondary: "text-gray-700 bg-gray-50 border border-gray-300 hover:bg-gray-200 hover:border-gray-400 active:bg-gray-300 focus:ring-purple-400/40 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-500 dark:hover:bg-gray-800 dark:hover:border-gray-600 dark:active:bg-gray-900",
         error: "text-white bg-red-600 border border-red-600 hover:bg-red-700 active:bg-red-800 focus:ring-red-500/40 dark:bg-red-500 dark:border-red-500 dark:hover:bg-red-600 dark:active:bg-red-700",
         link: "text-purple-300 dark:text-purple-400 hover:text-purple-500 dark:hover:text-purple-200 active:underline hover:underline aria-pressed:text-purple-500 aria-pressed:underline aria-pressed:font-bold dark:aria-pressed:text-purple-200 active:font-bold"
       }.freeze
 
       ACTIVE_COLORS = {
         primary: "ring-2 ring-purple-400/40 bg-purple-600 dark:bg-purple-500",
-        secondary: "ring-2 ring-purple-400/40 bg-gray-100 border-gray-400 dark:bg-gray-700 dark:border-gray-500",
+        secondary: "ring-2 ring-purple-400/40 bg-gray-200 border-gray-400 dark:bg-gray-800 dark:border-gray-600",
         error: "ring-2 ring-red-500/40 bg-red-700 dark:bg-red-600",
         link: "text-purple-500 dark:text-purple-200 underline font-bold"
       }.freeze

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -27,6 +27,7 @@ document.addEventListener('turbo:load', localizeTime)
 document.addEventListener('turbo:render', localizeTime)
 document.addEventListener('turbo:frame-render', localizeTime)
 document.addEventListener('turbo:morph', localizeTime)
+document.addEventListener('turbo:morph-element', localizeTime)
 
 // const toggleChecks = (event) => {
 //   const checked = event.target.checked

--- a/app/javascript/controllers/punch_controller.js
+++ b/app/javascript/controllers/punch_controller.js
@@ -3,8 +3,10 @@ import { isPressed, press, unpress, setPressed, allPressed } from 'utils/aria_pr
 import { readUrlSelection, writeUrlSelection } from 'utils/punchcard_url'
 
 // data-controller="punch". Selection state is aria-pressed on the DOM
-// itself (punches drive everything; group buttons reflect their punches;
-// empty-day ridge bars use selectedEmptyDays since they have no punches).
+// itself; selectedDays records explicit day-group intent (ridge-bar clicks
+// and Show all activities). Day intent is what differentiates ?days= from
+// ?selected=user:day in the URL: clicking individual punches never adds to
+// selectedDays, even if every punch on that day happens to be pressed.
 //
 // Across a turbo morph: capture group intent on turbo:before-morph-element,
 // rebuild + re-apply on turbo:morph-element. Indexing uses querySelectorAll
@@ -18,11 +20,7 @@ const appendToMapKey = (map, key, value) => {
   map.get(key).push(value)
 }
 
-const toggleSetMember = (set, value) => {
-  if (set.has(value)) set.delete(value); else set.add(value)
-}
-
-const emptyIntent = () => ({ allActive: false, users: new Set(), days: new Set() })
+const emptyIntent = () => ({ allActive: false, users: new Set() })
 
 // ---- Stimulus controller ----------------------------------------------
 
@@ -32,7 +30,7 @@ export default class extends Controller {
   // === Lifecycle =========================================================
 
   connect () {
-    this.selectedEmptyDays = new Set()
+    this.selectedDays = new Set()
     this.capturedIntent = emptyIntent()
     this.beforeMorphHandler = (event) => {
       if (event.target === this.element) this.captureActiveGroups()
@@ -63,9 +61,8 @@ export default class extends Controller {
 
   rebuild () {
     this.indexDom()
-    this.selectedEmptyDays = new Set()
+    this.selectedDays = new Set()
     this.applyUrlSelection()
-    this.pruneSelectedEmptyDays()
     this.applyCapturedGroups()
     this.sync()
     this.syncUrl()
@@ -114,51 +111,42 @@ export default class extends Controller {
     })
     days.forEach(day => {
       const date = this.dateStringForDay(day)
-      if (date) this.selectedEmptyDays.add(date)
+      if (!date) return
+      this.selectedDays.add(date)
+      ;(this.punchesByDate.get(date) || []).forEach(press)
     })
   }
 
   syncUrl () {
     const byUser = new Map()
     this.punches.filter(isPressed).forEach(el => {
+      if (this.selectedDays.has(el.dataset.date)) return
       appendToMapKey(byUser, el.dataset.userSlug, el._punchDay)
     })
-    const days = Array.from(this.selectedEmptyDays).map(d => parseInt(d.slice(-2), 10))
+    const days = Array.from(this.selectedDays).map(d => parseInt(d.slice(-2), 10))
     writeUrlSelection({ byUser, days })
-  }
-
-  // Dates with punches now have their state derived from those punches, so
-  // drop them from selectedEmptyDays (which is only meaningful for dates
-  // that have zero punches).
-  pruneSelectedEmptyDays () {
-    for (const date of [...this.selectedEmptyDays]) {
-      if (this.punchesByDate.has(date)) this.selectedEmptyDays.delete(date)
-    }
   }
 
   // === Group intent captured / replayed across morph =====================
 
   captureActiveGroups () {
     if (allPressed(this.punches)) {
-      this.capturedIntent = { allActive: true, users: new Set(), days: new Set() }
+      this.capturedIntent = { allActive: true, users: new Set() }
       return
     }
     const users = new Set()
-    const days = new Set()
     this.punchesByUser.forEach((els, slug) => { if (allPressed(els)) users.add(slug) })
-    this.punchesByDate.forEach((els, date) => { if (allPressed(els)) days.add(date) })
-    this.selectedEmptyDays.forEach(date => days.add(date))
-    this.capturedIntent = { allActive: false, users, days }
+    this.capturedIntent = { allActive: false, users }
   }
 
   applyCapturedGroups () {
-    const { allActive, users, days } = this.capturedIntent
+    const { allActive, users } = this.capturedIntent
     if (allActive) {
       this.punches.forEach(press)
       return
     }
     users.forEach(slug => (this.punchesByUser.get(slug) || []).forEach(press))
-    days.forEach(date => (this.punchesByDate.get(date) || []).forEach(press))
+    this.selectedDays.forEach(date => (this.punchesByDate.get(date) || []).forEach(press))
   }
 
   // === User actions ======================================================
@@ -171,13 +159,14 @@ export default class extends Controller {
 
   toggleDay (event) {
     const date = event.currentTarget.dataset.date
-    const punches = this.punchesByDate.get(date)
-    if (punches && punches.length > 0) {
-      this.toggleGroup(punches)
+    if (this.selectedDays.has(date)) {
+      this.selectedDays.delete(date)
+      ;(this.punchesByDate.get(date) || []).forEach(unpress)
     } else {
-      toggleSetMember(this.selectedEmptyDays, date)
-      this.afterToggle()
+      this.selectedDays.add(date)
+      ;(this.punchesByDate.get(date) || []).forEach(press)
     }
+    this.afterToggle()
   }
 
   toggleUser (event) {
@@ -191,10 +180,32 @@ export default class extends Controller {
     this.afterToggle()
   }
 
-  showAll () { this.punches.forEach(press); this.afterToggle() }
-  hideAll () { this.punches.forEach(unpress); this.afterToggle() }
+  showAll () {
+    this.punches.forEach(press)
+    this.ridgeBars.forEach(bar => this.selectedDays.add(bar.dataset.date))
+    this.afterToggle()
+  }
+
+  hideAll () {
+    this.punches.forEach(unpress)
+    this.selectedDays.clear()
+    this.afterToggle()
+  }
+
+  // Drop selectedDays entries whose punches are no longer all pressed —
+  // unpressing any individual punch on a day breaks the day-group intent
+  // and the URL switches from days= back to selected=.
+  pruneSelectedDays () {
+    for (const date of [...this.selectedDays]) {
+      const punches = this.punchesByDate.get(date) || []
+      if (punches.length > 0 && punches.some(el => !isPressed(el))) {
+        this.selectedDays.delete(date)
+      }
+    }
+  }
 
   afterToggle () {
+    this.pruneSelectedDays()
     this.sync()
     this.syncUrl()
   }
@@ -212,7 +223,7 @@ export default class extends Controller {
     this.ridgeBars.forEach(bar => {
       const date = bar.dataset.date
       const punches = this.punchesByDate.get(date) || []
-      const on = punches.length > 0 ? allPressed(punches) : this.selectedEmptyDays.has(date)
+      const on = punches.length > 0 ? allPressed(punches) : this.selectedDays.has(date)
       setPressed(bar, on)
     })
   }

--- a/spec/components/form/group/component_system_spec.rb
+++ b/spec/components/form/group/component_system_spec.rb
@@ -5,11 +5,13 @@ require "rails_helper"
 RSpec.describe Form::Group::Component, :js, type: :system do
   it "renders the label/input and is accessible in light and dark themes" do
     visit "/lookbook/preview/form/group/kinds"
+
     expect(page).to have_css("label")
     expect(page).to have_css("input")
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
 
     visit "/lookbook/preview/form/group/kinds?lookbook[display][theme]=dark"
+
     expect(page).to have_css("label")
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
   end

--- a/spec/components/form/group/component_system_spec.rb
+++ b/spec/components/form/group/component_system_spec.rb
@@ -3,17 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Form::Group::Component, :js, type: :system do
-  it "renders label and input" do
+  it "renders the label/input and is accessible in light and dark themes" do
     visit "/lookbook/preview/form/group/kinds"
-
     expect(page).to have_css("label")
     expect(page).to have_css("input")
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
-  end
 
-  it "is accessible in dark mode" do
     visit "/lookbook/preview/form/group/kinds?lookbook[display][theme]=dark"
-
     expect(page).to have_css("label")
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
   end

--- a/spec/components/settings_modal/component_system_spec.rb
+++ b/spec/components/settings_modal/component_system_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe SettingsModal::Component, :js, type: :system do
   it "opens, shows the theme/units sections, and closes" do
     visit "/lookbook/preview/settings_modal/default"
+
     expect(page).to have_no_css("dialog[open]")
 
     click_button("Open Settings")

--- a/spec/components/settings_modal/component_system_spec.rb
+++ b/spec/components/settings_modal/component_system_spec.rb
@@ -3,19 +3,16 @@
 require "rails_helper"
 
 RSpec.describe SettingsModal::Component, :js, type: :system do
-  it "opens and closes" do
+  it "opens, shows the theme/units sections, and closes" do
     visit "/lookbook/preview/settings_modal/default"
-
     expect(page).to have_no_css("dialog[open]")
 
     click_button("Open Settings")
-
     expect(page).to have_css("dialog[open]")
     expect(page).to have_content("Theme")
     expect(page).to have_content("Units")
 
-    find("button[data-action='click->ui--modal#close']").click
-
+    find('[aria-label="Close"]').click
     expect(page).to have_no_css("dialog[open]")
   end
 end

--- a/spec/components/ui/alert/component_system_spec.rb
+++ b/spec/components/ui/alert/component_system_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe UI::Alert::Component, :js, type: :system do
   it "is dismissable and accessible in light and dark themes" do
     visit "/lookbook/preview/ui/alert/dismissable_variants"
+
     expect(page).to have_content "Dismissable"
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
 
@@ -12,6 +13,7 @@ RSpec.describe UI::Alert::Component, :js, type: :system do
     expect(page).to have_css('[role="alert"]') # at least one alert remains (the other variant)
 
     visit "/lookbook/preview/ui/alert/dismissable_variants?lookbook[display][theme]=dark"
+
     expect(page).to have_content "Dismissable"
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
   end

--- a/spec/components/ui/alert/component_system_spec.rb
+++ b/spec/components/ui/alert/component_system_spec.rb
@@ -3,19 +3,15 @@
 require "rails_helper"
 
 RSpec.describe UI::Alert::Component, :js, type: :system do
-  it "is dismissable" do
+  it "is dismissable and accessible in light and dark themes" do
     visit "/lookbook/preview/ui/alert/dismissable_variants"
-
     expect(page).to have_content "Dismissable"
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
 
     first('button[aria-label="Close"]').click
     expect(page).to have_css('[role="alert"]') # at least one alert remains (the other variant)
-  end
 
-  it "is accessible in dark mode" do
     visit "/lookbook/preview/ui/alert/dismissable_variants?lookbook[display][theme]=dark"
-
     expect(page).to have_content "Dismissable"
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
   end

--- a/spec/components/ui/badge/component_system_spec.rb
+++ b/spec/components/ui/badge/component_system_spec.rb
@@ -3,11 +3,15 @@
 require "rails_helper"
 
 RSpec.describe UI::Badge::Component, :js, type: :system do
-  let(:preview_url) { "/lookbook/preview/ui/badge/colors" }
+  it "wraps a tooltip when title differs and renders plain badges otherwise" do
+    visit "/lookbook/preview/ui/badge/colors"
 
-  it "wraps the badge in a UI::Tooltip when title differs from text" do
-    visit preview_url
+    # Plain badge (no custom title) renders without a tooltip wrapper.
+    expect(page).to have_css("span.cursor-default")
+    expect(page).to have_text "Donor"
 
+    # Badge with a distinct title is wrapped in a hidden tooltip that
+    # reveals on hover.
     tooltip = find("[role='tooltip']", visible: :all)
     expect(tooltip.text(:all)).to eq "Notice"
     expect(tooltip).not_to be_visible
@@ -18,14 +22,6 @@ RSpec.describe UI::Badge::Component, :js, type: :system do
     expect(trigger.find("span.cursor-help")).to be_present
 
     trigger.hover
-
     expect(tooltip).to be_visible
-  end
-
-  it "renders badges without a tooltip when no custom title is provided" do
-    visit preview_url
-
-    expect(page).to have_css("span.cursor-default")
-    expect(page).to have_text "Donor"
   end
 end

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UI::Button::Component, type: :component do
   it "renders with default secondary style" do
     expect(component).to have_text("Click me")
     html = component.to_html
-    expect(html).to include("bg-white")
+    expect(html).to include("bg-gray-50")
     expect(html).to include("border-gray-300")
   end
 
@@ -54,7 +54,7 @@ RSpec.describe UI::Button::Component, type: :component do
   context "invalid color" do
     let(:options) { {color: :nope} }
     it "falls back to secondary" do
-      expect(component.to_html).to include("bg-white")
+      expect(component.to_html).to include("bg-gray-50")
     end
   end
 end

--- a/spec/components/ui/button_link/component_spec.rb
+++ b/spec/components/ui/button_link/component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UI::ButtonLink::Component, type: :component do
   it "renders a link with secondary style" do
     expect(component).to have_link("Click me", href: "/test")
     html = component.to_html
-    expect(html).to include("bg-white")
+    expect(html).to include("bg-gray-50")
     expect(html).to include("cursor-pointer")
   end
 

--- a/spec/components/ui/dropdown/component_system_spec.rb
+++ b/spec/components/ui/dropdown/component_system_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe UI::Dropdown::Component, :js, type: :system do
   it "opens on click, is accessible, and closes on escape" do
     visit "/lookbook/preview/ui/dropdown/variants"
+
     expect(page).to have_css('[aria-expanded="false"]')
 
     click_button("Menu")

--- a/spec/components/ui/dropdown/component_system_spec.rb
+++ b/spec/components/ui/dropdown/component_system_spec.rb
@@ -3,20 +3,15 @@
 require "rails_helper"
 
 RSpec.describe UI::Dropdown::Component, :js, type: :system do
-  context "when interacting with the dropdown" do
-    it "opens and closes" do
-      visit "/lookbook/preview/ui/dropdown/variants"
+  it "opens on click, is accessible, and closes on escape" do
+    visit "/lookbook/preview/ui/dropdown/variants"
+    expect(page).to have_css('[aria-expanded="false"]')
 
-      expect(page).to have_css('[aria-expanded="false"]')
+    click_button("Menu")
+    expect(page).to have_css('[aria-expanded="true"]')
+    expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
 
-      click_button("Menu")
-
-      expect(page).to have_css('[aria-expanded="true"]')
-      expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
-
-      send_keys(:escape)
-
-      expect(page).to have_css('[aria-expanded="false"]')
-    end
+    send_keys(:escape)
+    expect(page).to have_css('[aria-expanded="false"]')
   end
 end

--- a/spec/components/ui/modal/component_system_spec.rb
+++ b/spec/components/ui/modal/component_system_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe UI::Modal::Component, :js, type: :system do
   it "opens, closes via the close button, and dismisses on escape" do
     visit "/lookbook/preview/ui/modal/default"
+
     expect(page).to have_no_css("dialog[open]")
 
     click_button("Open Settings")

--- a/spec/components/ui/modal/component_system_spec.rb
+++ b/spec/components/ui/modal/component_system_spec.rb
@@ -3,34 +3,22 @@
 require "rails_helper"
 
 RSpec.describe UI::Modal::Component, :js, type: :system do
-  context "when interacting with the modal" do
-    it "opens and closes" do
-      visit "/lookbook/preview/ui/modal/default"
+  it "opens, closes via the close button, and dismisses on escape" do
+    visit "/lookbook/preview/ui/modal/default"
+    expect(page).to have_no_css("dialog[open]")
 
-      expect(page).to have_no_css("dialog[open]")
+    click_button("Open Settings")
+    expect(page).to have_css("dialog[open]")
+    expect(page).to have_content("Modal body content")
+    expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
 
-      click_button("Open Settings")
+    find('[aria-label="Close"]').click
+    expect(page).to have_no_css("dialog[open]")
 
-      expect(page).to have_css("dialog[open]")
-      expect(page).to have_content("Modal body content")
-      expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
+    click_button("Open Settings")
+    expect(page).to have_css("dialog[open]")
 
-      find("button[data-action='click->ui--modal#close']").click
-
-      expect(page).to have_no_css("dialog[open]")
-    end
-  end
-
-  context "when pressing escape" do
-    it "closes the modal" do
-      visit "/lookbook/preview/ui/modal/default"
-
-      click_button("Open Settings")
-      expect(page).to have_css("dialog[open]")
-
-      send_keys(:escape)
-
-      expect(page).to have_no_css("dialog[open]")
-    end
+    send_keys(:escape)
+    expect(page).to have_no_css("dialog[open]")
   end
 end

--- a/spec/components/ui/tooltip/component_system_spec.rb
+++ b/spec/components/ui/tooltip/component_system_spec.rb
@@ -70,7 +70,10 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     expect(first_tooltip).not_to be_visible
 
     # ----- Layering: clicking each trigger in order raises z-index ----
-    find("body").click # clear any focused tooltip from the previous phase
+    # The trailing tooltip from the previous phase is closed by the first
+    # iteration's focus shift, then reopens on its own iteration with a
+    # freshly bumped z-index, so we can run the loop directly against the
+    # carried state.
     tooltips.each { |t| find("[aria-describedby='#{t[:id]}']").click }
     z_indexes = tooltips.map { |t| tooltip_z_index(t[:id]).to_i }
     expect(z_indexes).to eq z_indexes.sort
@@ -78,6 +81,7 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
 
     # ----- Dark mode renders and is accessible ------------------------
     visit "#{preview_url}?lookbook[display][theme]=dark"
+
     expect(page).to have_css("[role='tooltip']", visible: :all)
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
   end

--- a/spec/components/ui/tooltip/component_system_spec.rb
+++ b/spec/components/ui/tooltip/component_system_spec.rb
@@ -5,131 +5,79 @@ require "rails_helper"
 RSpec.describe UI::Tooltip::Component, :js, type: :system do
   let(:preview_url) { "/lookbook/preview/ui/tooltip/variants" }
 
-  it "is accessible and reveals on hover, hides on mouseleave" do
-    visit preview_url
-
-    tooltip = first("[role='tooltip']", visible: :all)
-    expect(tooltip.text(:all)).to eq "5–9 mi"
-    expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
-    expect(tooltip).not_to be_visible
-
-    find("[aria-describedby='#{tooltip[:id]}']").hover
-
-    expect(tooltip).to be_visible
-    expect(tooltip_position(tooltip[:id])).to include("top" => be_present, "left" => be_present)
-
-    find("body").hover
-
-    expect(tooltip).not_to be_visible
-  end
-
-  it "stays open when shown via focus until clicking elsewhere" do
-    visit preview_url
-
-    tooltip = first("[role='tooltip']", visible: :all)
-    trigger = find("[aria-describedby='#{tooltip[:id]}']")
-
-    page.execute_script("arguments[0].focus()", trigger)
-    expect(tooltip).to be_visible
-
-    find("body").click
-    expect(tooltip).not_to be_visible
-  end
-
-  it "stays visible when tabbed into while hovered, until focus and hover both clear" do
-    visit preview_url
-
-    tooltip = first("[role='tooltip']", visible: :all)
-    trigger = find("[aria-describedby='#{tooltip[:id]}']")
-
-    trigger.hover
-    expect(tooltip).to be_visible
-
-    page.execute_script("arguments[0].focus()", trigger)
-    expect(tooltip).to be_visible
-
-    find("body").hover
-    expect(tooltip).to be_visible
-
-    page.execute_script("arguments[0].blur()", trigger)
-    expect(tooltip).not_to be_visible
-  end
-
-  it "stays visible when hovered while focused, through mouseleave" do
-    visit preview_url
-
-    tooltip = first("[role='tooltip']", visible: :all)
-    trigger = find("[aria-describedby='#{tooltip[:id]}']")
-
-    page.execute_script("arguments[0].focus()", trigger)
-    trigger.hover
-    expect(tooltip).to be_visible
-
-    find("body").hover
-    expect(tooltip).to be_visible
-
-    page.execute_script("arguments[0].blur()", trigger)
-    expect(tooltip).not_to be_visible
-  end
-
-  it "click-outside only dismisses a focus-activated tooltip, not a hover-only one" do
-    visit preview_url
-
-    tooltip = first("[role='tooltip']", visible: :all)
-    trigger = find("[aria-describedby='#{tooltip[:id]}']")
-
-    trigger.hover
-    expect(tooltip).to be_visible
-
-    page.execute_script("document.body.click()")
-    expect(tooltip).to be_visible
-  end
-
-  it "hides when focus moves to another element" do
-    visit preview_url
-
-    tooltips = all("[role='tooltip']", visible: :all)
-    triggers = tooltips.map { |t| find("[aria-describedby='#{t[:id]}']") }
-
-    page.execute_script("arguments[0].focus()", triggers.first)
-    expect(tooltips.first).to be_visible
-
-    page.execute_script("arguments[0].focus()", triggers.last)
-    expect(tooltips.first).not_to be_visible
-  end
-
-  it "persists when the trigger is clicked, even after mouseleave" do
-    visit preview_url
-
-    tooltip = first("[role='tooltip']", visible: :all)
-    trigger = find("[aria-describedby='#{tooltip[:id]}']")
-
-    trigger.hover
-    trigger.click
-    find("body").hover
-
-    expect(tooltip).to be_visible
-
-    find("body").click
-    expect(tooltip).not_to be_visible
-  end
-
-  it "layers the most recently activated tooltip in front" do
+  it "shows on hover/focus, latches on click, layers in front, and is accessible in light & dark" do
     visit preview_url
 
     tooltips = all("[role='tooltip']", visible: :all)
     expect(tooltips.size).to be >= 2
 
-    tooltips.each { |t| find("[aria-describedby='#{t[:id]}']").click }
+    first_tooltip = tooltips.first
+    first_trigger = find("[aria-describedby='#{first_tooltip[:id]}']")
 
+    # ----- Initial state ----------------------------------------------
+    expect(first_tooltip.text(:all)).to eq "5–9 mi"
+    expect(first_tooltip).not_to be_visible
+    expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
+
+    # ----- Hover reveals; mouseleave hides ----------------------------
+    first_trigger.hover
+    expect(first_tooltip).to be_visible
+    expect(tooltip_position(first_tooltip[:id])).to include("top" => be_present, "left" => be_present)
+
+    find("body").hover
+    expect(first_tooltip).not_to be_visible
+
+    # ----- Hover-only state isn't dismissed by click outside ----------
+    first_trigger.hover
+    page.execute_script("document.body.click()")
+    expect(first_tooltip).to be_visible
+
+    find("body").hover
+    expect(first_tooltip).not_to be_visible
+
+    # ----- Focus reveals; click outside dismisses ---------------------
+    page.execute_script("arguments[0].focus()", first_trigger)
+    expect(first_tooltip).to be_visible
+
+    find("body").click
+    expect(first_tooltip).not_to be_visible
+
+    # ----- Focus + hover stays through mouseleave; blur clears it -----
+    page.execute_script("arguments[0].focus()", first_trigger)
+    first_trigger.hover
+    expect(first_tooltip).to be_visible
+
+    find("body").hover
+    expect(first_tooltip).to be_visible
+
+    page.execute_script("arguments[0].blur()", first_trigger)
+    expect(first_tooltip).not_to be_visible
+
+    # ----- Click latches: stays after mouseleave, dismissed by outside click ----
+    first_trigger.hover
+    first_trigger.click
+    find("body").hover
+    expect(first_tooltip).to be_visible
+
+    find("body").click
+    expect(first_tooltip).not_to be_visible
+
+    # ----- Focus moving to another trigger hides the first ------------
+    page.execute_script("arguments[0].focus()", first_trigger)
+    expect(first_tooltip).to be_visible
+
+    page.execute_script("arguments[0].focus()", find("[aria-describedby='#{tooltips.last[:id]}']"))
+    expect(first_tooltip).not_to be_visible
+
+    # ----- Layering: clicking each trigger in order raises z-index ----
+    find("body").click # clear any focused tooltip from the previous phase
+    tooltips.each { |t| find("[aria-describedby='#{t[:id]}']").click }
     z_indexes = tooltips.map { |t| tooltip_z_index(t[:id]).to_i }
     expect(z_indexes).to eq z_indexes.sort
     expect(z_indexes.last).to be > z_indexes.first
-  end
 
-  it "is accessible in dark mode" do
+    # ----- Dark mode renders and is accessible ------------------------
     visit "#{preview_url}?lookbook[display][theme]=dark"
-
     expect(page).to have_css("[role='tooltip']", visible: :all)
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
   end

--- a/spec/components/user_dropdown/component_system_spec.rb
+++ b/spec/components/user_dropdown/component_system_spec.rb
@@ -3,15 +3,10 @@
 require "rails_helper"
 
 RSpec.describe UserDropdown::Component, :js, type: :system do
-  it "signed_out renders sign in" do
+  it "renders the signed-out and signed-in states on the lookbook preview" do
     visit "/lookbook/preview/user_dropdown/states"
 
     expect(page).to have_button("Sign in")
-  end
-
-  it "signed_in renders user dropdown" do
-    visit "/lookbook/preview/user_dropdown/states"
-
     expect(page).to have_text("Rider")
     expect(page).to have_button(id: "user-menu-button")
   end

--- a/spec/integration/landing_spec.rb
+++ b/spec/integration/landing_spec.rb
@@ -3,35 +3,28 @@
 require "rails_helper"
 
 RSpec.describe "Landing page", :js, type: :system do
-  it "visits root and is accessible" do
+  it "renders the heading, is accessible, and lets the user toggle dark mode" do
+    # Pin the OS-level preference to light before visiting so the dark-mode
+    # toggle assertions don't depend on the developer's machine.
+    visit "about:blank"
+    page.driver.browser.execute_cdp(
+      "Emulation.setEmulatedMedia",
+      features: [{name: "prefers-color-scheme", value: "light"}]
+    )
+
     visit root_path
 
     expect(page).to have_css("h1", text: /MIBM/)
     expect(page).to be_axe_clean.skipping(SKIPPABLE_AXE_RULES)
-  end
+    expect(page).to have_no_css("html.dark")
 
-  context "when changing theme from settings" do
-    it "toggles dark mode" do
-      visit "about:blank"
-      page.driver.browser.execute_cdp(
-        "Emulation.setEmulatedMedia",
-        features: [{name: "prefers-color-scheme", value: "light"}]
-      )
+    find("button[data-open-modal='user-settings-modal']").click
+    expect(page).to have_css("dialog[open]")
 
-      visit root_path
+    find("button[data-theme='theme_dark']").click
+    expect(page).to have_css("html.dark")
 
-      expect(page).to have_no_css("html.dark")
-
-      find("button[data-open-modal='user-settings-modal']").click
-      expect(page).to have_css("dialog[open]")
-
-      find("button[data-theme='theme_dark']").click
-
-      expect(page).to have_css("html.dark")
-
-      find("button[data-theme='theme_light']").click
-
-      expect(page).to have_no_css("html.dark")
-    end
+    find("button[data-theme='theme_light']").click
+    expect(page).to have_no_css("html.dark")
   end
 end

--- a/spec/integration/punchcard/live_update_spec.rb
+++ b/spec/integration/punchcard/live_update_spec.rb
@@ -190,4 +190,22 @@ RSpec.describe "Punchcard live update", :js, type: :system do
       expect(find(%([data-punch-target="ridgeBar"][data-date="2026-05-03"]))["aria-pressed"]).to eq "true"
     end
   end
+
+  describe "localizeTime spans morphed in by ActionCable" do
+    # Regression: turbo stream broadcasts use morph and fire
+    # `turbo:morph-element` (not `turbo:morph`). New `.localizeTime` spans
+    # (e.g. the footer's "updated" time) must still get localized.
+    it "localizes them on turbo:morph-element" do
+      page.execute_script(<<~JS, wrapper_id)
+        const wrapper = document.getElementById(arguments[0])
+        const span = document.createElement('span')
+        span.className = 'localizeTime'
+        span.textContent = '2026-05-20T11:00:00+0000'
+        wrapper.appendChild(span)
+        wrapper.dispatchEvent(new CustomEvent('turbo:morph-element', { bubbles: true }))
+      JS
+
+      expect(page).to have_css("##{wrapper_id} > span.localizedTime", wait: 2)
+    end
+  end
 end

--- a/spec/integration/punchcard/live_update_spec.rb
+++ b/spec/integration/punchcard/live_update_spec.rb
@@ -191,6 +191,70 @@ RSpec.describe "Punchcard live update", :js, type: :system do
     end
   end
 
+  describe "URL: ?days= reflects explicit day-group intent only" do
+    # bob_day5 makes day 5 have two punches so we can distinguish
+    # "ridge-bar click" from "every individual punch clicked".
+    let!(:bob_day5) do
+      FactoryBot.create(:competition_activity, competition_user: bob_cu,
+        distance_meters: 16_093, start_at: Time.parse("2026-05-05T15:00:00Z"))
+    end
+
+    # Re-visit after bob_day5 is created so the rendered page has both
+    # day-5 punches (the outer `before` runs visit before the inner let!).
+    before { visit root_path }
+
+    let(:day5_ridge) { find(%([data-punch-target="ridgeBar"][data-date="2026-05-05"])) }
+
+    context "when the day's ridge bar is clicked" do
+      it "writes ?days= and re-presses both punches on reload" do
+        day5_ridge.click
+
+        expect(page.current_url).to include "days=5"
+        expect(page.current_url).not_to include "selected="
+
+        visit page.current_url
+        expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")))).to be true
+        expect(pressed?(find(punch_selector(user_slug: bob.slug, date_string: "2026-05-05")))).to be true
+      end
+
+      context "and a punch on that day is then unpressed" do
+        it "drops ?days= and writes the remaining press to ?selected=" do
+          day5_ridge.click
+
+          find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")).click
+
+          expect(page.current_url).not_to include "days=5"
+          expect(page.current_url).to include "selected=#{bob.slug}%3A5"
+          expect(page.current_url).not_to include "#{alice.slug}%3A5"
+        end
+      end
+    end
+
+    context "when every individual punch on a day is pressed (without clicking the day)" do
+      it "writes ?selected= per-user, never ?days=" do
+        find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")).click
+        find(punch_selector(user_slug: bob.slug, date_string: "2026-05-05")).click
+
+        expect(page.current_url).not_to include "days=5"
+        expect(page.current_url).to include "selected="
+        expect(page.current_url).to include "#{alice.slug}%3A5"
+        expect(page.current_url).to include "#{bob.slug}%3A5"
+      end
+    end
+
+    context "when 'Show all activities' is clicked" do
+      it "writes every available day to ?days= and not ?selected=" do
+        click_button("Show all activities")
+
+        # All ridge bar dates (May 1–20, since the test runs at 2026-05-20)
+        # land in days=, comma-encoded as %2C.
+        expected_days = (1..20).to_a.join("%2C")
+        expect(page.current_url).to include "days=#{expected_days}"
+        expect(page.current_url).not_to include "selected="
+      end
+    end
+  end
+
   describe "localizeTime spans morphed in by ActionCable" do
     # Regression: turbo stream broadcasts use morph and fire
     # `turbo:morph-element` (not `turbo:morph`). New `.localizeTime` spans

--- a/spec/integration/punchcard/live_update_spec.rb
+++ b/spec/integration/punchcard/live_update_spec.rb
@@ -2,16 +2,15 @@
 
 require "rails_helper"
 
-# Walks the punchcard's full client-side state machine in one example:
-# user/day/all-active intent capture across a real ActionCable morph,
-# DOM indexing of newly-arrived punches, ?days= vs ?selected= URL
-# semantics, URL persistence across reload, and footer time
-# localization after a broadcast.
+# Walks the punchcard's full client-side state machine in one example,
+# state advancing from click to click — never resetting back to a clean
+# slate. Each phase's starting state is the previous phase's end state;
+# phase order is chosen so the carried state is exactly what the next
+# claim wants to demonstrate.
 #
 # Morphs are produced by real ActionCable broadcasts — the `:test` cable
 # adapter inherits from `:async`, so broadcasts in-process do round-trip
-# to the browser. `click_button("Hide all activities")` is the reset
-# between phases (it clears every press AND in-memory selectedDays).
+# to the browser.
 RSpec.describe "Punchcard live update", :js, type: :system do
   around { |ex| travel_to(Time.parse("2026-05-20T12:00:00Z")) { ex.run } }
 
@@ -62,138 +61,122 @@ RSpec.describe "Punchcard live update", :js, type: :system do
     find("button", text: "Show all activities")
   end
 
+  def url_params
+    URI.decode_www_form(URI.parse(page.current_url).query || "").to_h
+  end
+
+  def url_days
+    url_params["days"]&.split(",") || []
+  end
+
+  def url_selected
+    url_params["selected"] || ""
+  end
+
   before do
     visit root_path
     expect(page).to have_css('[data-controller="punch"] [data-punch-target="punch"]')
   end
 
   it "captures intents, indexes morphed punches, persists URL state, and localizes broadcast footers" do
-    # ----- Show-all button reflects aria-pressed across toggles ---------
-    expect(show_all_button["aria-pressed"]).to eq "false"
-
-    click_button("Show all activities")
-    expect(show_all_button["aria-pressed"]).to eq "true"
-
-    punch_for(alice, "2026-05-05").click
-    expect(show_all_button["aria-pressed"]).to eq "false"
-
-    click_button("Hide all activities")
-
-    # ----- User-row capture: Alice's row stays full across morph -------
-    # Clicking Alice presses her two punches. Morph adds alice:15; the
-    # URL has no day 15 entry and day 15 isn't fully active, so only
-    # user-capture can press the new punch.
-    click_button("Alice")
-    expect(pressed?(punch_for(alice, "2026-05-05"))).to be true
-    expect(pressed?(punch_for(alice, "2026-05-10"))).to be true
-
-    morph_in_punch(user: alice, date_string: "2026-05-15")
-    expect(pressed?(punch_for(alice, "2026-05-15"))).to be true
-
-    click_button("Hide all activities")
-
-    # ----- Day-ridge capture: day 5 stays full across morph ------------
-    # Clicking the day-5 ridge presses just alice:5 (her row is partial,
-    # so user-capture won't fire). Morph adds bob:5 — only day-capture
-    # can press it.
-    ridge_for("2026-05-05").click
-    expect(pressed?(punch_for(alice, "2026-05-05"))).to be true
-    expect(pressed?(punch_for(alice, "2026-05-10"))).to be false
-
-    morph_in_punch(user: bob, date_string: "2026-05-05")
-    expect(pressed?(punch_for(bob, "2026-05-05"))).to be true
-
-    click_button("Hide all activities")
-
-    # ----- All-active capture: Show-all stays pressed across morph -----
-    # bob has no prior punches before phase D, so user-capture can't
-    # cover bob:7; allActive does.
-    click_button("Show all activities")
-    expect(show_all_button["aria-pressed"]).to eq "true"
-
-    morph_in_punch(user: bob, date_string: "2026-05-07")
-    expect(pressed?(punch_for(bob, "2026-05-07"))).to be true
-    expect(show_all_button["aria-pressed"]).to eq "true"
-
-    click_button("Hide all activities")
-
-    # ----- Indexing regression: morph-added punches are queryable -----
-    # The controller previously read `this.punchTargets` from Stimulus
-    # inside the synchronous morph handler, which was stale because
-    # Stimulus updates targets via MutationObserver on the next
-    # microtask. Without prior intent, alice:17 must still be indexed
-    # so clicking the day-17 ridge presses it.
-    morph_in_punch(user: alice, date_string: "2026-05-17")
-    ridge_for("2026-05-17").click
-    expect(pressed?(punch_for(alice, "2026-05-17"))).to be true
-    expect(ridge_for("2026-05-17")["aria-pressed"]).to eq "true"
-
-    click_button("Hide all activities")
-
-    # ----- Empty-day ridge: toggle, persistence, reload, then morph ---
-    # Day 1 has no activity from anyone; its ridge bar is a button but
-    # has no punches to toggle. Selection is tracked in selectedDays,
-    # serialized to ?days=, and survives reload — at which point a
-    # morph-added punch for that day is auto-pressed via day-capture.
+    # ----- Empty-day ridge: toggle, ?days= persistence, reload, then morph ----
+    # Day 1 has no activity from anyone; its ridge bar is a button with no
+    # punches to toggle. Selection lives in selectedDays, serialized to
+    # `?days=1`, and survives reload — a morph-added punch on that day is
+    # auto-pressed via day-capture.
     expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "false"
 
     ridge_for("2026-05-01").click
     expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "true"
-    expect(page.current_url).to include "days=1"
+    expect(url_days).to eq ["1"]
 
     ridge_for("2026-05-01").click
     expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "false"
-    expect(page.current_url).not_to include "days=1"
+    expect(url_days).to be_empty
 
     ridge_for("2026-05-01").click
     visit page.current_url
+
     expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "true"
 
     morph_in_punch(user: alice, date_string: "2026-05-01")
     expect(pressed?(punch_for(alice, "2026-05-01"))).to be true
     expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "true"
 
-    click_button("Hide all activities")
+    # ----- Indexing regression: morph-added punches are queryable -----
+    # The controller previously read `this.punchTargets` from Stimulus
+    # inside the synchronous morph handler, which was stale because
+    # Stimulus updates targets via MutationObserver on the next
+    # microtask. Carry-state-wise, day 17 has no prior intent — the new
+    # punch must still be indexed so clicking the day-17 ridge presses it.
+    morph_in_punch(user: alice, date_string: "2026-05-17")
+    ridge_for("2026-05-17").click
+    expect(pressed?(punch_for(alice, "2026-05-17"))).to be true
 
-    # ----- ?days= reflects explicit day-group intent only --------------
-    # Day 5 now has two punches (alice:5 from fixtures + bob:5 from the
-    # earlier morph), so we can distinguish "ridge-bar click" from
-    # "every individual punch clicked" on the same day.
+    # ----- Day-ridge capture across morph + ?days= URL semantics -----
+    # Click day 5 ridge bar with day 5 not yet in selectedDays. The click
+    # adds it (URL gains `days=5`) and presses alice:5. Day 10 — also
+    # alice's, but on a different day — stays unpressed: ridge clicks are
+    # scoped to their own date.
     ridge_for("2026-05-05").click
-    expect(page.current_url).to include "days=5"
-    expect(page.current_url).not_to include "selected="
-
-    visit page.current_url
     expect(pressed?(punch_for(alice, "2026-05-05"))).to be true
+    expect(pressed?(punch_for(alice, "2026-05-10"))).to be false
+    expect(url_days).to include "5"
+
+    # Morph adds bob:5 — day 5 is in selectedDays, so the new punch is
+    # pressed via day-capture even though bob has no other punches.
+    morph_in_punch(user: bob, date_string: "2026-05-05")
     expect(pressed?(punch_for(bob, "2026-05-05"))).to be true
 
-    # Unpressing any punch on a "selected day" drops the day and the
-    # remaining press is written to ?selected=.
+    # ----- Unpressing a punch on a "selected day" drops the day ----------
+    # alice:5 unpressed → day 5 no longer fully active → drops from
+    # selectedDays; the remaining bob:5 is written individually.
     punch_for(alice, "2026-05-05").click
-    expect(page.current_url).not_to include "days=5"
-    expect(page.current_url).to include "selected=#{bob.slug}%3A5"
-    expect(page.current_url).not_to include "#{alice.slug}%3A5"
+    expect(url_days).not_to include "5"
+    expect(url_selected).to include "#{bob.slug}:5"
+    expect(url_selected).not_to include "#{alice.slug}:5"
 
-    click_button("Hide all activities")
-    expect(page.current_url).not_to include "days="
-    expect(page.current_url).not_to include "selected="
-
-    # Pressing every individual punch on a day never adds to ?days=.
+    # Pressing alice:5 again, individually, never re-adds day 5 to days=.
     punch_for(alice, "2026-05-05").click
-    punch_for(bob, "2026-05-05").click
-    expect(page.current_url).not_to include "days=5"
-    expect(page.current_url).to include "#{alice.slug}%3A5"
-    expect(page.current_url).to include "#{bob.slug}%3A5"
+    expect(url_days).not_to include "5"
+    expect(url_selected).to include "#{alice.slug}:5"
+    expect(url_selected).to include "#{bob.slug}:5"
 
-    click_button("Hide all activities")
+    # ----- User-row capture across morph -----
+    # Clicking Alice toggles every alice punch as a group. Some are
+    # pressed and some aren't (alice:10 has been unpressed since fixture
+    # setup), so the toggle presses all of them. Morph adds alice:15 —
+    # alice's row was fully active before the morph, so user-capture
+    # presses the new punch.
+    click_button("Alice")
+    expect(pressed?(punch_for(alice, "2026-05-10"))).to be true
 
-    # 'Show all activities' adds every available day to ?days=.
+    morph_in_punch(user: alice, date_string: "2026-05-15")
+    expect(pressed?(punch_for(alice, "2026-05-15"))).to be true
+
+    # ----- All-active capture + 'Show all activities' → ?days=all -----
+    # Show all presses every punch and adds every available day to
+    # selectedDays, so the URL collapses to `days=1,2,…,20` with no
+    # `selected=`.
     click_button("Show all activities")
-    expected_days = (1..20).to_a.join("%2C")
-    expect(page.current_url).to include "days=#{expected_days}"
-    expect(page.current_url).not_to include "selected="
+    expect(show_all_button["aria-pressed"]).to eq "true"
+    expect(url_days).to eq (1..20).map(&:to_s)
+    expect(url_selected).to be_empty
 
-    click_button("Hide all activities")
+    # Bob has no punch on day 7. Morph adds it; allActive captured before
+    # the morph presses everything, so bob:7 arrives pressed and Show-all
+    # stays aria-pressed.
+    morph_in_punch(user: bob, date_string: "2026-05-07")
+    expect(pressed?(punch_for(bob, "2026-05-07"))).to be true
+    expect(show_all_button["aria-pressed"]).to eq "true"
+
+    # ----- Show-all button reflects aria-pressed across toggles ----
+    # Unpressing any punch breaks the all-active state.
+    punch_for(alice, "2026-05-05").click
+    expect(show_all_button["aria-pressed"]).to eq "false"
+
+    click_button("Show all activities")
+    expect(show_all_button["aria-pressed"]).to eq "true"
 
     # ----- Footer 'updated' time gets localized after broadcast --------
     # Regression: turbo stream broadcasts use morph and fire

--- a/spec/integration/punchcard/live_update_spec.rb
+++ b/spec/integration/punchcard/live_update_spec.rb
@@ -2,20 +2,16 @@
 
 require "rails_helper"
 
-# Exercises the `punch` Stimulus controller, which preserves user selection
-# across turbo morphs. These tests synthesize the turbo morph lifecycle by
-# dispatching `turbo:before-morph-element` / `turbo:morph-element` on the
-# wrapper and mutating the DOM in between, rather than relying on
-# ActionCable broadcasts (the test adapter doesn't round-trip to the
-# browser).
+# Walks the punchcard's full client-side state machine in one example:
+# user/day/all-active intent capture across a real ActionCable morph,
+# DOM indexing of newly-arrived punches, ?days= vs ?selected= URL
+# semantics, URL persistence across reload, and footer time
+# localization after a broadcast.
 #
-# Fixture setup isolates the three capture paths:
-# - Alice has two activities (days 5 and 10), so clicking her user button is
-#   meaningfully different from clicking either punch individually.
-# - Bob is in the competition but starts with no activity — his row exists
-#   but has zero punch buttons. A morph-added punch for Bob can therefore
-#   only become pressed via day-capture or all-capture, never via URL
-#   reapply.
+# Morphs are produced by real ActionCable broadcasts — the `:test` cable
+# adapter inherits from `:async`, so broadcasts in-process do round-trip
+# to the browser. `click_button("Hide all activities")` is the reset
+# between phases (it clears every press AND in-memory selectedDays).
 RSpec.describe "Punchcard live update", :js, type: :system do
   around { |ex| travel_to(Time.parse("2026-05-20T12:00:00Z")) { ex.run } }
 
@@ -34,40 +30,28 @@ RSpec.describe "Punchcard live update", :js, type: :system do
       distance_meters: 16_093, start_at: Time.parse("2026-05-10T15:00:00Z"))
   end
 
-  let(:wrapper_id) { ActionView::RecordIdentifier.dom_id(competition, :punchcard_wrapper) }
-
-  # Synthesize a turbo morph: optionally fire the capture phase, append a new
-  # punch button to the target user's row, then fire the morph-element event.
-  def morph_in_punch(user_slug:, date_string:, before_morph: true)
-    page.execute_script(<<~JS, wrapper_id, user_slug, date_string, before_morph)
-      const [wrapperId, userSlug, dateString, beforeMorph] = arguments
-      const wrapper = document.getElementById(wrapperId)
-      if (beforeMorph) {
-        wrapper.dispatchEvent(new CustomEvent('turbo:before-morph-element', { bubbles: true }))
-      }
-      const row = wrapper.querySelectorAll('.punchcard-week')[
-        Array.from(wrapper.querySelectorAll('[data-punch-target="userButton"]'))
-          .findIndex(btn => btn.dataset.userSlug === userSlug)
-      ]
-      const btn = document.createElement('button')
-      btn.type = 'button'
-      btn.className = 'punchcard-cell'
-      btn.setAttribute('aria-pressed', 'false')
-      btn.dataset.action = 'click->punch#toggle'
-      btn.dataset.punchTarget = 'punch'
-      btn.dataset.punchId = `${userSlug}-${dateString}`
-      btn.dataset.date = dateString
-      btn.dataset.userSlug = userSlug
-      btn.dataset.l = '1'
-      row.appendChild(btn)
-      wrapper.dispatchEvent(new CustomEvent('turbo:morph-element', { bubbles: true }))
-    JS
-    # Wait for the microtask-debounced rebuild to run.
-    page.evaluate_script("new Promise(r => queueMicrotask(() => queueMicrotask(r)))")
+  # Add an activity for the given user on the given date, then broadcast a
+  # punchcard refresh. The test cable adapter delivers in-process to the
+  # turbo_stream_from subscription, so the browser receives a morph and
+  # renders the new punch.
+  def morph_in_punch(user:, date_string:)
+    competition_user = CompetitionUser.find_by!(user:, competition:)
+    FactoryBot.create(:competition_activity, competition_user:,
+      distance_meters: 16_093, start_at: Time.parse("#{date_string}T15:00:00Z"))
+    Leaderboard::PunchcardWrapper::Component.broadcast_refresh_current!
+    expect(page).to have_css(punch_selector(user_slug: user.slug, date_string:), wait: 5)
   end
 
   def punch_selector(user_slug:, date_string:)
     %([data-punch-target="punch"][data-user-slug="#{user_slug}"][data-date="#{date_string}"])
+  end
+
+  def punch_for(user, date_string)
+    find(punch_selector(user_slug: user.slug, date_string:))
+  end
+
+  def ridge_for(date_string)
+    find(%([data-punch-target="ridgeBar"][data-date="#{date_string}"]))
   end
 
   def pressed?(node)
@@ -83,193 +67,146 @@ RSpec.describe "Punchcard live update", :js, type: :system do
     expect(page).to have_css('[data-controller="punch"] [data-punch-target="punch"]')
   end
 
-  describe "'Show all activities' button active state" do
-    it "is aria-pressed when every punch is active and clears when any is deselected" do
-      expect(show_all_button["aria-pressed"]).to eq "false"
+  it "captures intents, indexes morphed punches, persists URL state, and localizes broadcast footers" do
+    # ----- Show-all button reflects aria-pressed across toggles ---------
+    expect(show_all_button["aria-pressed"]).to eq "false"
 
-      click_button("Show all activities")
+    click_button("Show all activities")
+    expect(show_all_button["aria-pressed"]).to eq "true"
 
-      expect(show_all_button["aria-pressed"]).to eq "true"
+    punch_for(alice, "2026-05-05").click
+    expect(show_all_button["aria-pressed"]).to eq "false"
 
-      find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")).click
+    click_button("Hide all activities")
 
-      expect(show_all_button["aria-pressed"]).to eq "false"
-    end
-  end
+    # ----- User-row capture: Alice's row stays full across morph -------
+    # Clicking Alice presses her two punches. Morph adds alice:15; the
+    # URL has no day 15 entry and day 15 isn't fully active, so only
+    # user-capture can press the new punch.
+    click_button("Alice")
+    expect(pressed?(punch_for(alice, "2026-05-05"))).to be true
+    expect(pressed?(punch_for(alice, "2026-05-10"))).to be true
 
-  describe "group intent preserved across morph" do
-    context "when a user row is fully active" do
-      # Alice has days 5 and 10. Clicking her button activates both. A morph
-      # then adds day 15 — neither the URL (no day 15 entry) nor day-capture
-      # (no day is fully active) would press it; only user-capture can.
-      it "activates newly-rendered punches for that user" do
-        click_button("Alice")
-        expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")))).to be true
-        expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-10")))).to be true
+    morph_in_punch(user: alice, date_string: "2026-05-15")
+    expect(pressed?(punch_for(alice, "2026-05-15"))).to be true
 
-        morph_in_punch(user_slug: alice.slug, date_string: "2026-05-15")
+    click_button("Hide all activities")
 
-        expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-15")))).to be true
-      end
-    end
+    # ----- Day-ridge capture: day 5 stays full across morph ------------
+    # Clicking the day-5 ridge presses just alice:5 (her row is partial,
+    # so user-capture won't fire). Morph adds bob:5 — only day-capture
+    # can press it.
+    ridge_for("2026-05-05").click
+    expect(pressed?(punch_for(alice, "2026-05-05"))).to be true
+    expect(pressed?(punch_for(alice, "2026-05-10"))).to be false
 
-    context "when a specific day ridge bar is fully active" do
-      # Click day 5 ridge bar → only alice:5 is pressed. Alice's row is NOT
-      # fully active (day 10 is unpressed), so she won't be captured as an
-      # active user. Morph adds bob:day5 — only day-capture can press it.
-      it "activates newly-rendered punches for that date" do
-        find(%([data-punch-target="ridgeBar"][data-date="2026-05-05"])).click
-        expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")))).to be true
-        expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-10")))).to be false
+    morph_in_punch(user: bob, date_string: "2026-05-05")
+    expect(pressed?(punch_for(bob, "2026-05-05"))).to be true
 
-        morph_in_punch(user_slug: bob.slug, date_string: "2026-05-05")
+    click_button("Hide all activities")
 
-        expect(pressed?(find(punch_selector(user_slug: bob.slug, date_string: "2026-05-05")))).to be true
-      end
-    end
+    # ----- All-active capture: Show-all stays pressed across morph -----
+    # bob has no prior punches before phase D, so user-capture can't
+    # cover bob:7; allActive does.
+    click_button("Show all activities")
+    expect(show_all_button["aria-pressed"]).to eq "true"
 
-    context "when all activities are shown" do
-      # Click "Show all" → both alice punches pressed, everything active.
-      # Morph adds bob:day5 — bob has no prior punches so he can't be in
-      # activeUsers, but allActive covers him.
-      it "activates newly-rendered punches and keeps the button aria-pressed" do
-        click_button("Show all activities")
+    morph_in_punch(user: bob, date_string: "2026-05-07")
+    expect(pressed?(punch_for(bob, "2026-05-07"))).to be true
+    expect(show_all_button["aria-pressed"]).to eq "true"
 
-        morph_in_punch(user_slug: bob.slug, date_string: "2026-05-05")
+    click_button("Hide all activities")
 
-        expect(pressed?(find(punch_selector(user_slug: bob.slug, date_string: "2026-05-05")))).to be true
-        expect(show_all_button["aria-pressed"]).to eq "true"
-      end
-    end
-  end
+    # ----- Indexing regression: morph-added punches are queryable -----
+    # The controller previously read `this.punchTargets` from Stimulus
+    # inside the synchronous morph handler, which was stale because
+    # Stimulus updates targets via MutationObserver on the next
+    # microtask. Without prior intent, alice:17 must still be indexed
+    # so clicking the day-17 ridge presses it.
+    morph_in_punch(user: alice, date_string: "2026-05-17")
+    ridge_for("2026-05-17").click
+    expect(pressed?(punch_for(alice, "2026-05-17"))).to be true
+    expect(ridge_for("2026-05-17")["aria-pressed"]).to eq "true"
 
-  describe "punches added by morph are indexed immediately" do
-    # Regression: the controller previously read `this.punchTargets` from
-    # Stimulus inside the synchronous morph handler, which was stale because
-    # Stimulus updates targets via MutationObserver on the next microtask.
-    # New punches weren't in `punchesByDate`, so clicking the day's ridge bar
-    # was a no-op.
-    it "lets the ridge bar activate a punch that arrived during the morph" do
-      morph_in_punch(user_slug: alice.slug, date_string: "2026-05-15", before_morph: false)
+    click_button("Hide all activities")
 
-      find(%([data-punch-target="ridgeBar"][data-date="2026-05-15"])).click
+    # ----- Empty-day ridge: toggle, persistence, reload, then morph ---
+    # Day 1 has no activity from anyone; its ridge bar is a button but
+    # has no punches to toggle. Selection is tracked in selectedDays,
+    # serialized to ?days=, and survives reload — at which point a
+    # morph-added punch for that day is auto-pressed via day-capture.
+    expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "false"
 
-      expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-15")))).to be true
-      expect(find(%([data-punch-target="ridgeBar"][data-date="2026-05-15"]))["aria-pressed"]).to eq "true"
-    end
-  end
+    ridge_for("2026-05-01").click
+    expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "true"
+    expect(page.current_url).to include "days=1"
 
-  describe "selecting a day that has no activity yet" do
-    # Day 3 has no activity from anyone; its ridge bar renders as a button
-    # (past/today) but previously did nothing on click because there were
-    # no punches to toggle.
-    let(:day3_ridge) { find(%([data-punch-target="ridgeBar"][data-date="2026-05-03"])) }
+    ridge_for("2026-05-01").click
+    expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "false"
+    expect(page.current_url).not_to include "days=1"
 
-    it "toggles aria-pressed, persists to ?days=, survives reload, and picks up morphed-in punches" do
-      expect(day3_ridge["aria-pressed"]).to eq "false"
+    ridge_for("2026-05-01").click
+    visit page.current_url
+    expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "true"
 
-      day3_ridge.click
-      expect(day3_ridge["aria-pressed"]).to eq "true"
-      expect(page.current_url).to include "days=3"
+    morph_in_punch(user: alice, date_string: "2026-05-01")
+    expect(pressed?(punch_for(alice, "2026-05-01"))).to be true
+    expect(ridge_for("2026-05-01")["aria-pressed"]).to eq "true"
 
-      # Second click toggles off.
-      day3_ridge.click
-      expect(day3_ridge["aria-pressed"]).to eq "false"
-      expect(page.current_url).not_to include "days=3"
+    click_button("Hide all activities")
 
-      # Re-select, then reload: URL persistence restores the selection.
-      day3_ridge.click
-      visit page.current_url
-      reloaded_ridge = find(%([data-punch-target="ridgeBar"][data-date="2026-05-03"]))
-      expect(reloaded_ridge["aria-pressed"]).to eq "true"
+    # ----- ?days= reflects explicit day-group intent only --------------
+    # Day 5 now has two punches (alice:5 from fixtures + bob:5 from the
+    # earlier morph), so we can distinguish "ridge-bar click" from
+    # "every individual punch clicked" on the same day.
+    ridge_for("2026-05-05").click
+    expect(page.current_url).to include "days=5"
+    expect(page.current_url).not_to include "selected="
 
-      # A subsequent morph brings in a punch for that day — it arrives pressed
-      # because day 3 is captured as active.
-      morph_in_punch(user_slug: alice.slug, date_string: "2026-05-03")
-      expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-03")))).to be true
-      expect(find(%([data-punch-target="ridgeBar"][data-date="2026-05-03"]))["aria-pressed"]).to eq "true"
-    end
-  end
+    visit page.current_url
+    expect(pressed?(punch_for(alice, "2026-05-05"))).to be true
+    expect(pressed?(punch_for(bob, "2026-05-05"))).to be true
 
-  describe "URL: ?days= reflects explicit day-group intent only" do
-    # bob_day5 makes day 5 have two punches so we can distinguish
-    # "ridge-bar click" from "every individual punch clicked".
-    let!(:bob_day5) do
-      FactoryBot.create(:competition_activity, competition_user: bob_cu,
-        distance_meters: 16_093, start_at: Time.parse("2026-05-05T15:00:00Z"))
-    end
+    # Unpressing any punch on a "selected day" drops the day and the
+    # remaining press is written to ?selected=.
+    punch_for(alice, "2026-05-05").click
+    expect(page.current_url).not_to include "days=5"
+    expect(page.current_url).to include "selected=#{bob.slug}%3A5"
+    expect(page.current_url).not_to include "#{alice.slug}%3A5"
 
-    # Re-visit after bob_day5 is created so the rendered page has both
-    # day-5 punches (the outer `before` runs visit before the inner let!).
-    before { visit root_path }
+    click_button("Hide all activities")
+    expect(page.current_url).not_to include "days="
+    expect(page.current_url).not_to include "selected="
 
-    let(:day5_ridge) { find(%([data-punch-target="ridgeBar"][data-date="2026-05-05"])) }
+    # Pressing every individual punch on a day never adds to ?days=.
+    punch_for(alice, "2026-05-05").click
+    punch_for(bob, "2026-05-05").click
+    expect(page.current_url).not_to include "days=5"
+    expect(page.current_url).to include "#{alice.slug}%3A5"
+    expect(page.current_url).to include "#{bob.slug}%3A5"
 
-    context "when the day's ridge bar is clicked" do
-      it "writes ?days= and re-presses both punches on reload" do
-        day5_ridge.click
+    click_button("Hide all activities")
 
-        expect(page.current_url).to include "days=5"
-        expect(page.current_url).not_to include "selected="
+    # 'Show all activities' adds every available day to ?days=.
+    click_button("Show all activities")
+    expected_days = (1..20).to_a.join("%2C")
+    expect(page.current_url).to include "days=#{expected_days}"
+    expect(page.current_url).not_to include "selected="
 
-        visit page.current_url
-        expect(pressed?(find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")))).to be true
-        expect(pressed?(find(punch_selector(user_slug: bob.slug, date_string: "2026-05-05")))).to be true
-      end
+    click_button("Hide all activities")
 
-      context "and a punch on that day is then unpressed" do
-        it "drops ?days= and writes the remaining press to ?selected=" do
-          day5_ridge.click
-
-          find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")).click
-
-          expect(page.current_url).not_to include "days=5"
-          expect(page.current_url).to include "selected=#{bob.slug}%3A5"
-          expect(page.current_url).not_to include "#{alice.slug}%3A5"
-        end
-      end
-    end
-
-    context "when every individual punch on a day is pressed (without clicking the day)" do
-      it "writes ?selected= per-user, never ?days=" do
-        find(punch_selector(user_slug: alice.slug, date_string: "2026-05-05")).click
-        find(punch_selector(user_slug: bob.slug, date_string: "2026-05-05")).click
-
-        expect(page.current_url).not_to include "days=5"
-        expect(page.current_url).to include "selected="
-        expect(page.current_url).to include "#{alice.slug}%3A5"
-        expect(page.current_url).to include "#{bob.slug}%3A5"
-      end
-    end
-
-    context "when 'Show all activities' is clicked" do
-      it "writes every available day to ?days= and not ?selected=" do
-        click_button("Show all activities")
-
-        # All ridge bar dates (May 1–20, since the test runs at 2026-05-20)
-        # land in days=, comma-encoded as %2C.
-        expected_days = (1..20).to_a.join("%2C")
-        expect(page.current_url).to include "days=#{expected_days}"
-        expect(page.current_url).not_to include "selected="
-      end
-    end
-  end
-
-  describe "localizeTime spans morphed in by ActionCable" do
+    # ----- Footer 'updated' time gets localized after broadcast --------
     # Regression: turbo stream broadcasts use morph and fire
-    # `turbo:morph-element` (not `turbo:morph`). New `.localizeTime` spans
-    # (e.g. the footer's "updated" time) must still get localized.
-    it "localizes them on turbo:morph-element" do
-      page.execute_script(<<~JS, wrapper_id)
-        const wrapper = document.getElementById(arguments[0])
-        const span = document.createElement('span')
-        span.className = 'localizeTime'
-        span.textContent = '2026-05-20T11:00:00+0000'
-        wrapper.appendChild(span)
-        wrapper.dispatchEvent(new CustomEvent('turbo:morph-element', { bubbles: true }))
-      JS
+    # `turbo:morph-element` (not `turbo:morph`), so the `.localizeTime`
+    # span rendered into the footer by the morph must still get
+    # localized by the time-localizer.
+    expect(page).not_to have_css(".localizeTime")
+    expect(page).not_to have_css(".localizedTime")
 
-      expect(page).to have_css("##{wrapper_id} > span.localizedTime", wait: 2)
-    end
+    FactoryBot.create(:strava_request, user: alice, created_at: Time.parse("2026-05-20T11:30:00Z"))
+    Leaderboard::PunchcardWrapper::Component.broadcast_refresh_current!
+
+    expect(page).to have_css(".localizedTime", wait: 5)
+    expect(page).not_to have_css(".localizeTime")
   end
 end


### PR DESCRIPTION
Localizes the punchcard footer's "updated" time after ActionCable morphs, switches the leaderboard's `?days=` URL parameter to track explicit ridge-bar / Show-all intent, syncs dark-mode alert/button polish from bikeindex/bike_index#3485, and adds an `integration-testing` skill that drove the consolidation of every browser spec.

- **Footer time localization**: `application.js` listens for `turbo:morph-element` in addition to `turbo:morph`, so the `localizeTime` span re-rendered by `PunchcardWrapper#broadcast_refresh!` actually gets converted to `localizedTime`.
- **`?days=N` is opt-in**: the punch controller's `selectedDays` set is populated only by ridge-bar clicks and "Show all"; individual punch clicks stay on `?selected=user:day,…`, and unpressing a punch on a `selectedDays` day drops the day.
- **Dark-mode polish (sync from bike_index#3485)**: `UI::Alert` uses variant-tinted `dark:bg-{color}-950` instead of a uniform `dark:bg-purple-800`; `UI::Button[:secondary]` shifts its gray scale so each interaction step darkens.
- **`integration-testing` skill** drove the consolidation: `live_update_spec.rb` collapses six describes into one walked-through example, seven component system specs collapse to single examples (25 → 12 total), and `landing_spec.rb` folds accessibility into the dark-mode test. `agents.md` is trimmed to defer testing/frontend/PR detail to the new skill plus `rspec-testing` / `frontend-conventions` / `pr`.
