### PR TITLE
Add admin index for competition activities

### DIFF
--- a/app/components/navbar/component.html.erb
+++ b/app/components/navbar/component.html.erb
@@ -10,6 +10,7 @@
 
   <%= helpers.active_link "Competitions", admin_competitions_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Competition Users", admin_competition_users_path, class: "twlink ml-2", match_controller: true %>
+  <%= helpers.active_link "Competition Activities", admin_competition_activities_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Users", admin_users_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Strava Requests", admin_strava_requests_path, class: "twlink ml-2", match_controller: true %>
   <%= link_to "Exit", root_url, class: "twlink ml-auto less-strong" %>

--- a/app/controllers/admin/competition_activities_controller.rb
+++ b/app/controllers/admin/competition_activities_controller.rb
@@ -1,0 +1,62 @@
+module Admin
+  class CompetitionActivitiesController < Admin::BaseController
+    include Binxtils::SortableTable
+
+    helper_method :competition_user_subject
+
+    def index
+      @matching_competition_activities = searched_competition_activities
+      @pagy, @competition_activities = pagy(:countish,
+        @matching_competition_activities
+          .reorder("competition_activities.#{sort_column} #{sort_direction}")
+          .includes(competition_user: %i[user competition]),
+        limit: per_page, page:)
+    end
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at start_at distance_meters competition_user_id included_in_competition]
+    end
+
+    def competition_user_subject
+      return @competition_user_subject if defined?(@competition_user_subject)
+
+      cu_id = params.permit(:search_competition_user_id)[:search_competition_user_id]
+      @competition_user_subject = cu_id.present? ? CompetitionUser.find_by(id: cu_id) : nil
+    end
+
+    def competition_subject
+      return @competition_subject if defined?(@competition_subject)
+
+      return @competition_subject = competition_user_subject.competition if competition_user_subject.present?
+
+      competition_params = params.permit(:competition_id, :search_competition_id)
+      competition_id = competition_params[:competition_id].presence || competition_params[:search_competition_id].presence
+      @competition_subject = if competition_id == "all"
+        nil
+      elsif competition_id.present?
+        Competition.friendly_find(competition_id)
+      else
+        Competition.current
+      end
+    end
+
+    def searched_competition_activities
+      activities = CompetitionActivity
+      if competition_user_subject.present?
+        activities = activities.where(competition_user_id: competition_user_subject.id)
+      elsif competition_subject.present?
+        activities = activities.joins(:competition_user)
+          .where(competition_users: {competition_id: competition_subject.id})
+      end
+      if user_subject.present?
+        activities = activities.joins(:competition_user)
+          .where(competition_users: {user_id: user_subject.id})
+      end
+
+      @time_range_column = (sort_column == "updated_at") ? "updated_at" : "created_at"
+      activities.where("competition_activities.#{@time_range_column}" => @time_range)
+    end
+  end
+end

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -1,0 +1,51 @@
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: competition_user_subject.blank?, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, period: @period, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competition_activities, time_range: @time_range, time_range_column: @time_range_column)) %>
+
+<% if competition_user_subject.present? %>
+  <p class="mb-2">
+    Activities for competition user:
+    <strong><%= competition_user_subject.display_name %></strong> in
+    <strong><%= competition_user_subject.competition.display_name %></strong>
+    <span class="less-strong"><em>&ndash; <%= link_to "view all activities", url_for(sortable_params.merge(search_competition_user_id: nil)), class: "twlink" %></em></span>
+  </p>
+<% end %>
+
+<%# Local var because cell blocks run via instance_exec in the table component context %>
+<% show_dev_info = display_dev_info? %>
+
+<%= render(UI::Table::Component.new(records: @competition_activities, render_sortable: true, sticky: true)) do |table|
+  table.column(sortable: "created_at", lower_right: (->(ca) { ca.id } if show_dev_info)) do |ca|
+    render(UI::Time::Component.new(time: ca.created_at))
+  end
+
+  table.column(sortable: "start_at", label: "Start") do |ca|
+    render(UI::Time::Component.new(time: ca.start_at))
+  end
+
+  table.column(label: "Activity") do |ca|
+    link_to(ca.display_name.presence || ca.strava_id, ca.strava_url, class: "twlink", target: "_blank", rel: "noopener")
+  end
+
+  table.column(sortable: "competition_user_id", label: "User") do |ca|
+    link_to(ca.competition_user.display_name, admin_competition_activities_path(search_competition_user_id: ca.competition_user_id), class: "twlink")
+  end
+
+  if competition_subject.blank?
+    table.column(label: "Competition") { |ca| ca.competition&.display_name }
+  end
+
+  table.column(sortable: "distance_meters", label: "Distance (m)") { |ca| number_display(ca.distance_meters&.round) }
+
+  table.column(label: "Elevation (m)") { |ca| number_display(ca.elevation_meters&.round) }
+
+  table.column(label: "Type") { |ca| ca.strava_type }
+
+  table.column(sortable: "included_in_competition", label: "Included?") { |ca| check_mark if ca.included_in_competition }
+
+  if show_dev_info
+    table.column(sortable: "updated_at") do |ca|
+      render(UI::Time::Component.new(time: ca.updated_at))
+    end
+  end
+end %>
+
+<%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: sortable_params)) %>

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -33,9 +33,23 @@
     table.column(label: "Competition") { |ca| ca.competition&.display_name }
   end
 
-  table.column(sortable: "distance_meters", label: "Distance (m)") { |ca| number_display(ca.distance_meters&.round) }
+  table.column(sortable: "distance_meters", label: "Distance") do |ca|
+    if ca.distance_meters
+      safe_join([
+        tag.span(safe_join([number_display(meters_to_miles(ca.distance_meters), round_to: 1), " mi"]), class: "unit-imperial"),
+        tag.span(safe_join([number_display(ca.distance_meters / 1000.0, round_to: 1), " km"]), class: "unit-metric hidden")
+      ])
+    end
+  end
 
-  table.column(label: "Elevation (m)") { |ca| number_display(ca.elevation_meters&.round) }
+  table.column(label: "Elevation") do |ca|
+    if ca.elevation_meters
+      safe_join([
+        tag.span(safe_join([number_display(meters_to_feet(ca.elevation_meters)), " ft"]), class: "unit-imperial"),
+        tag.span(safe_join([number_display(ca.elevation_meters), " m"]), class: "unit-metric hidden")
+      ])
+    end
+  end
 
   table.column(label: "Type") { |ca| ca.strava_type }
 

--- a/app/views/admin/competition_users/_table.html.erb
+++ b/app/views/admin/competition_users/_table.html.erb
@@ -22,7 +22,9 @@
     end
   end
 
-  table.column(label: "Activities") { |cu| number_display(cu.competition_activities.count) }
+  table.column(label: "Activities") do |cu|
+    link_to(number_display(cu.competition_activities.count), admin_competition_activities_path(search_competition_user_id: cu.id), class: "twlink")
+  end
 
   table.column(label: "Rank") do |cu|
     "#{cu.rank_in_competition}/#{cu.rider_count_in_competition}" if cu.included_in_competition

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: "competition_users#index"
+    resources :competition_activities, only: %i[index]
     resources :competitions, only: %i[index new create]
     resources :competition_users, only: %i[index edit update]
     resources :strava_requests, only: %i[index]

--- a/spec/requests/admin/competition_activities_request_spec.rb
+++ b/spec/requests/admin/competition_activities_request_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+base_url = "/admin/competition_activities"
+RSpec.describe base_url, type: :request do
+  describe "index" do
+    it "sets return to" do
+      get base_url
+      expect(response).to redirect_to root_url
+      expect(session[:user_return_to]).to eq base_url
+    end
+
+    context "signed in" do
+      include_context :logged_in_as_user
+      it "flash errors" do
+        get base_url
+        expect(response).to redirect_to root_url
+        expect(flash[:error]).to be_present
+      end
+    end
+  end
+
+  context "signed in as admin" do
+    include_context :logged_in_as_admin
+
+    describe "index" do
+      it "renders" do
+        get base_url
+        expect(response.code).to eq "200"
+        expect(response).to render_template("admin/competition_activities/index")
+      end
+
+      context "with activities across competitions" do
+        let(:competition1) { FactoryBot.create(:competition, start_date: Date.parse("2024-05-01")) }
+        let(:competition2) { FactoryBot.create(:competition) }
+        let(:competition_user1) { FactoryBot.create(:competition_user, competition: competition1) }
+        let(:competition_user2) { FactoryBot.create(:competition_user, competition: competition2) }
+        let!(:activity1) { FactoryBot.create(:competition_activity, competition_user: competition_user1) }
+        let!(:activity2) { FactoryBot.create(:competition_activity, competition_user: competition_user2) }
+
+        it "defaults to the current competition" do
+          expect(Competition.current).to eq competition2
+
+          get base_url
+          expect(response.code).to eq "200"
+          expect(assigns(:competition_subject)).to eq competition2
+          expect(assigns(:competition_activities).pluck(:id)).to eq([activity2.id])
+        end
+
+        it "filters by search_competition_id" do
+          get "#{base_url}?search_competition_id=#{competition1.id}"
+          expect(response.code).to eq "200"
+          expect(assigns(:competition_subject)).to eq competition1
+          expect(assigns(:competition_activities).pluck(:id)).to eq([activity1.id])
+        end
+
+        it "shows all competitions when search_competition_id=all" do
+          get "#{base_url}?search_competition_id=all"
+          expect(response.code).to eq "200"
+          expect(assigns(:competition_subject)).to be_nil
+          expect(assigns(:competition_activities).pluck(:id)).to match_array([activity1.id, activity2.id])
+        end
+
+        it "filters by search_competition_user_id" do
+          get "#{base_url}?search_competition_user_id=#{competition_user1.id}"
+          expect(response.code).to eq "200"
+          expect(assigns(:competition_user_subject)).to eq competition_user1
+          expect(assigns(:competition_subject)).to eq competition1
+          expect(assigns(:competition_activities).pluck(:id)).to eq([activity1.id])
+        end
+
+        it "filters by user" do
+          get "#{base_url}?search_competition_id=all&user=#{competition_user1.user.slug}"
+          expect(response.code).to eq "200"
+          expect(assigns(:user_subject)).to eq competition_user1.user
+          expect(assigns(:competition_activities).pluck(:id)).to eq([activity1.id])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new admin index for `CompetitionActivity` so we can browse activities directly instead of bouncing through the user table.

- New `/admin/competition_activities` index, filterable by competition (defaults to current, `search_competition_id=all` for cross-competition) and by competition user via `search_competition_user_id` (which auto-derives the competition and hides the competition picker).
- Activities column on the admin competition users table now links here scoped to that user, replacing the bare count.
- User column in the new table links back to itself filtered to that competition user, so you can pivot from any row.
- Linked from the admin navbar; distance and elevation render in the user's preferred unit (mi/ft or km/m) using the existing `unit-imperial` / `unit-metric` toggle.

## Screenshots

### /admin/competition_activities

| Desktop | Mobile |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5886c188-1ae1-47ac-bd27-b9cd9e79848d" width="600"> | <img src="https://github.com/user-attachments/assets/5bb988c4-47b4-4f40-9f32-8504ab501931" width="300"> |

### /admin/competition_activities?search_competition_user_id=…

| Desktop | Mobile |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/f9bdfd2f-4084-47b9-8edc-8e9e6b4516e1" width="600"> | <img src="https://github.com/user-attachments/assets/2c2194b8-9e1e-4daf-b924-40b0b0d6a06e" width="300"> |

### /admin/competition_users

| Desktop | Mobile |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ad04c60e-28ee-45ee-8cfe-37fe83fc529e" width="600"> | <img src="https://github.com/user-attachments/assets/42509ba3-31cc-473e-82dc-a7de5c4d1f74" width="300"> |
