### PR TITLE
Add admin navbar button to enqueue UpdateCompetitionUserJob

### DIFF
--- a/app/components/leaderboard/punchcard_footer/component.html.erb
+++ b/app/components/leaderboard/punchcard_footer/component.html.erb
@@ -25,7 +25,8 @@
 
   <% if @updated_at %>
     <div class="text-right">
-      updated <%= render(UI::Time::Component.new(time: @updated_at)) %>
+      updated
+      <%= render(UI::Time::Component.new(time: @updated_at, format: :localize_time_precise)) %>
     </div>
   <% end %>
 </div>

--- a/app/components/navbar/component.html.erb
+++ b/app/components/navbar/component.html.erb
@@ -1,6 +1,6 @@
-<ul
+<div
   class="
-    relative flex items-center gap-4 wrapper-padding justify-end mb-2
+    relative flex items-center gap-4 wrapper-padding mb-2
     bg-purple-100 dark:bg-purple-800 py-2
   "
 >
@@ -8,11 +8,26 @@
     May Is Bike Month Admin
   </span>
 
-  <%= helpers.active_link "Competitions", admin_competitions_path, class: "twlink ml-2", match_controller: true %>
-  <%= helpers.active_link "Competition Users", admin_competition_users_path, class: "twlink ml-2", match_controller: true %>
-  <%= helpers.active_link "Competition Activities", admin_competition_activities_path, class: "twlink ml-2", match_controller: true %>
-  <%= helpers.active_link "Users", admin_users_path, class: "twlink ml-2", match_controller: true %>
-  <%= helpers.active_link "Strava Requests", admin_strava_requests_path, class: "twlink ml-2", match_controller: true %>
+  <div class="md:hidden">
+    <%= render(UI::Dropdown::Component.new(
+      name: current_nav_item&.label || "Menu",
+      button_color: :link,
+      active: current_nav_item.present?
+    )) do |d| %>
+      <% nav_items.each do |item| %>
+        <% d.with_entry_item do %>
+          <%= helpers.active_link(item.label, item.path, class: "twlink", match_controller: true) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="hidden md:flex items-center gap-4">
+    <% nav_items.each do |item| %>
+      <%= helpers.active_link(item.label, item.path, class: "twlink", match_controller: true) %>
+    <% end %>
+  </div>
+
   <%= button_to "Update Competition", enqueue_update_job_admin_competition_users_path, method: :post, class: "twlink ml-auto", form: { class: "inline-block" } %>
   <%= link_to "Exit", root_url, class: "twlink less-strong" %>
-</ul>
+</div>

--- a/app/components/navbar/component.html.erb
+++ b/app/components/navbar/component.html.erb
@@ -13,6 +13,6 @@
   <%= helpers.active_link "Competition Activities", admin_competition_activities_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Users", admin_users_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Strava Requests", admin_strava_requests_path, class: "twlink ml-2", match_controller: true %>
-  <%= button_to "Run UpdateCompetitionUserJob", enqueue_update_job_admin_competition_users_path, method: :post, class: "twlink ml-auto", form: { class: "inline-block" } %>
+  <%= button_to "Update Competition", enqueue_update_job_admin_competition_users_path, method: :post, class: "twlink ml-auto", form: { class: "inline-block" } %>
   <%= link_to "Exit", root_url, class: "twlink less-strong" %>
 </ul>

--- a/app/components/navbar/component.html.erb
+++ b/app/components/navbar/component.html.erb
@@ -13,5 +13,6 @@
   <%= helpers.active_link "Competition Activities", admin_competition_activities_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Users", admin_users_path, class: "twlink ml-2", match_controller: true %>
   <%= helpers.active_link "Strava Requests", admin_strava_requests_path, class: "twlink ml-2", match_controller: true %>
-  <%= link_to "Exit", root_url, class: "twlink ml-auto less-strong" %>
+  <%= button_to "Run UpdateCompetitionUserJob", enqueue_update_job_admin_competition_users_path, method: :post, class: "twlink ml-auto", form: { class: "inline-block" } %>
+  <%= link_to "Exit", root_url, class: "twlink less-strong" %>
 </ul>

--- a/app/components/navbar/component.html.erb
+++ b/app/components/navbar/component.html.erb
@@ -19,6 +19,12 @@
           <%= helpers.active_link(item.label, item.path, class: "twlink", match_controller: true) %>
         <% end %>
       <% end %>
+
+      <% d.with_entry_divider %>
+
+      <% d.with_entry_item do %>
+        <%= button_to "Update Competition", enqueue_update_job_admin_competition_users_path, method: :post %>
+      <% end %>
     <% end %>
   </div>
 
@@ -26,8 +32,9 @@
     <% nav_items.each do |item| %>
       <%= helpers.active_link(item.label, item.path, class: "twlink", match_controller: true) %>
     <% end %>
+
+    <%= button_to "Update Competition", enqueue_update_job_admin_competition_users_path, method: :post, class: "twlink" %>
   </div>
 
-  <%= button_to "Update Competition", enqueue_update_job_admin_competition_users_path, method: :post, class: "twlink ml-auto", form: { class: "inline-block" } %>
-  <%= link_to "Exit", root_url, class: "twlink less-strong" %>
+  <%= link_to "Exit", root_url, class: "twlink less-strong ml-auto" %>
 </div>

--- a/app/components/navbar/component.rb
+++ b/app/components/navbar/component.rb
@@ -2,8 +2,26 @@
 
 module Navbar
   class Component < ApplicationComponent
+    NavItem = Data.define(:label, :path)
+
     def initialize(current_user:)
       @current_user = current_user
+    end
+
+    private
+
+    def nav_items
+      [
+        NavItem.new("Competitions", helpers.admin_competitions_path),
+        NavItem.new("Competition Users", helpers.admin_competition_users_path),
+        NavItem.new("Competition Activities", helpers.admin_competition_activities_path),
+        NavItem.new("Users", helpers.admin_users_path),
+        NavItem.new("Strava Requests", helpers.admin_strava_requests_path)
+      ]
+    end
+
+    def current_nav_item
+      nav_items.find { |item| helpers.current_page_active?(item.path, true) }
     end
   end
 end

--- a/app/controllers/admin/competition_users_controller.rb
+++ b/app/controllers/admin/competition_users_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class CompetitionUsersController < Admin::BaseController
     include Binxtils::SortableTable
 
-    before_action :find_competition_user, except: [:index]
+    before_action :find_competition_user, except: %i[index enqueue_update_job]
 
     def index
       @matching_competition_users = searched_competition_users
@@ -23,6 +23,15 @@ module Admin
       else
         render :edit, status: :see_other
       end
+    end
+
+    def enqueue_update_job
+      if UpdateCompetitionUserJob.enqueue_current
+        flash[:success] = "UpdateCompetitionUserJob enqueued"
+      else
+        flash[:error] = "No current competition"
+      end
+      redirect_back(fallback_location: admin_competition_users_path, status: :see_other)
     end
 
     private

--- a/app/jobs/process_strava_webhook_job.rb
+++ b/app/jobs/process_strava_webhook_job.rb
@@ -21,7 +21,7 @@ class ProcessStravaWebhookJob < ApplicationJob
       CompetitionActivity.joins(:competition_user)
         .where(competition_users: {user_id: user.id}, strava_id: params["object_id"].to_s)
         .destroy_all
-    elsif StravaRequest.update_due?
+    elsif !StravaRequest.over_rate_limit?
       competition_user = user.competition_users.current_competition.last
       UpdateCompetitionUserJob.perform_async(competition_user.id) if competition_user
     end

--- a/app/jobs/update_competition_user_job.rb
+++ b/app/jobs/update_competition_user_job.rb
@@ -7,8 +7,8 @@ class UpdateCompetitionUserJob < ApplicationJob
 
     competition.create_competition_users
 
-    # If an update isn't due, don't enqueue more jobs
-    return true unless StravaRequest.update_due?
+    # If we're over the rate limit, don't enqueue more jobs
+    return true if StravaRequest.over_rate_limit?
 
     # Maybe this should enqueue any without a recent request?
     CompetitionUser.included_in_current_competition.pluck(:id)

--- a/app/models/strava_request.rb
+++ b/app/models/strava_request.rb
@@ -20,8 +20,6 @@ class StravaRequest < ApplicationRecord
   SUCCESS_CODES = [200, 201].freeze
   # As of 2025-5-5, we get 3000 per day
   MAXIMUM_REQUESTS_PER_DAY = (ENV["STRAVA_MAX_REQUESTS_PER_HOUR"] || 3_000)&.to_i
-  # 2025 has 19 competitors - chose 5 minutes since we won't hit it much overnight
-  UPDATE_DELAY = 5.minutes
 
   enum :kind, KIND_ENUM
 
@@ -45,13 +43,6 @@ class StravaRequest < ApplicationRecord
       current_competition_users = Competition.current&.competition_users_included&.count || 0
       # if we're making requests, it will be for every user - so make sure we have space
       (responses + current_competition_users) > MAXIMUM_REQUESTS_PER_DAY
-    end
-
-    def update_due?
-      return false if over_rate_limit?
-
-      updated_at = most_recent_update
-      updated_at.blank? || updated_at < (Time.current - UPDATE_DELAY)
     end
 
     def update_competition_user_activities(competition_user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,11 @@ Rails.application.routes.draw do
     root to: "competition_users#index"
     resources :competition_activities, only: %i[index]
     resources :competitions, only: %i[index new create]
-    resources :competition_users, only: %i[index edit update]
+    resources :competition_users, only: %i[index edit update] do
+      collection do
+        post :enqueue_update_job
+      end
+    end
     resources :strava_requests, only: %i[index]
     resources :users, only: %i[index edit update]
   end

--- a/spec/models/strava_request_spec.rb
+++ b/spec/models/strava_request_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
 
 RSpec.describe StravaRequest, type: :model do
-  describe "update_due?" do
-    it "is true" do
-      expect(described_class.update_due?).to be_truthy
-    end
-  end
-
   describe "record_request_for_user_activities" do
     let(:user) { FactoryBot.create(:user_with_strava_token) }
     it "creates a strava_request" do

--- a/spec/requests/admin/competition_users_request_spec.rb
+++ b/spec/requests/admin/competition_users_request_spec.rb
@@ -109,5 +109,25 @@ RSpec.describe base_url, type: :request do
         expect(competition_user.included_in_competition).to be_falsey
       end
     end
+
+    describe "enqueue_update_job" do
+      context "with a current competition" do
+        let!(:competition) { FactoryBot.create(:competition, current: true) }
+        it "enqueues and flashes success" do
+          post "#{base_url}/enqueue_update_job"
+          expect(flash[:success]).to be_present
+          expect(response).to redirect_to admin_competition_users_path
+        end
+      end
+
+      context "without a current competition" do
+        it "flashes an error" do
+          expect(Competition.current).to be_nil
+          post "#{base_url}/enqueue_update_job"
+          expect(flash[:error]).to be_present
+          expect(response).to redirect_to admin_competition_users_path
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds an admin navbar button that POSTs to a new `enqueue_update_job` collection action on `Admin::CompetitionUsersController`, which calls `UpdateCompetitionUserJob.enqueue_current` and flashes success or "No current competition".

Also removes the unused `StravaRequest.update_due?` (the 5-minute throttle) — callers now check `over_rate_limit?` directly.

On mobile, the nav links and the Update Competition button collapse into a `UI::Dropdown` whose trigger label is the current page (active styling carries through to both the trigger and the menu item). Exit is right-aligned at all viewport sizes.

## Screenshots

### /admin/competition_users — desktop

<img src="https://github.com/user-attachments/assets/3b628a0b-c87c-49c8-8659-b42400485c04" width="800">

### /admin/competition_users — mobile

| Closed | Open |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/da3a93e6-775d-4718-98ea-f908d7f7bbcb" width="300"> | <img src="https://github.com/user-attachments/assets/68e3ca6a-1a28-4fbe-a25b-ac560ebf2a3b" width="300"> |
