### PR TITLE
Link admin activity user names to the competition user

### DIFF
--- a/app/components/admin/current_header/component.html.erb
+++ b/app/components/admin/current_header/component.html.erb
@@ -1,9 +1,14 @@
 <div class="mb-6" data-controller="admin--current-header">
-  <div class="flex justify-between items-baseline mb-4 gap-4">
+  <div
+    class="
+      flex flex-col lg:flex-row lg:justify-between lg:items-baseline mb-4
+      gap-4
+    "
+  >
     <h1><%= title %></h1>
 
     <div class="flex items-baseline gap-4">
-      <%= content if content.present? %>
+      <%= extra_action %>
       <%= link_to "graph", chart_toggle_url, class: chart_toggle_class %>
     </div>
   </div>

--- a/app/components/admin/current_header/component.rb
+++ b/app/components/admin/current_header/component.rb
@@ -3,6 +3,8 @@
 module Admin
   module CurrentHeader
     class Component < ApplicationComponent
+      renders_one :extra_action
+
       def initialize(viewing:, searchable_competitions:, s_params:, pagy:, include_competition_select: false, competition_subject: nil, user_subject: nil, user_param: nil, period: nil, render_chart: false, chart_collection: nil, time_range: nil, time_range_column: "created_at")
         @viewing = viewing
         @include_competition_select = include_competition_select

--- a/app/controllers/admin/competition_activities_controller.rb
+++ b/app/controllers/admin/competition_activities_controller.rb
@@ -2,7 +2,12 @@ module Admin
   class CompetitionActivitiesController < Admin::BaseController
     include Binxtils::SortableTable
 
-    helper_method :competition_user_subject
+    helper_method :competition_user_subject, :show_exclusion_reason?
+
+    def show_exclusion_reason?
+      return @show_exclusion_reason if defined?(@show_exclusion_reason)
+      @show_exclusion_reason = Binxtils::InputNormalizer.boolean(params[:search_show_exclusion_reason])
+    end
 
     def index
       @matching_competition_activities = searched_competition_activities

--- a/app/controllers/admin/competition_activities_controller.rb
+++ b/app/controllers/admin/competition_activities_controller.rb
@@ -2,14 +2,10 @@ module Admin
   class CompetitionActivitiesController < Admin::BaseController
     include Binxtils::SortableTable
 
-    helper_method :competition_user_subject, :show_exclusion_reason?
-
-    def show_exclusion_reason?
-      return @show_exclusion_reason if defined?(@show_exclusion_reason)
-      @show_exclusion_reason = Binxtils::InputNormalizer.boolean(params[:search_show_exclusion_reason])
-    end
+    helper_method :competition_user_subject
 
     def index
+      @show_exclusion_reason = Binxtils::InputNormalizer.boolean(params[:search_show_exclusion_reason])
       @matching_competition_activities = searched_competition_activities
       @pagy, @competition_activities = pagy(:countish,
         @matching_competition_activities
@@ -21,7 +17,7 @@ module Admin
     private
 
     def sortable_columns
-      %w[created_at updated_at start_at distance_meters competition_user_id included_in_competition]
+      %w[start_at created_at updated_at distance_meters competition_user_id included_in_competition]
     end
 
     def competition_user_subject

--- a/app/models/competition_activity.rb
+++ b/app/models/competition_activity.rb
@@ -132,6 +132,20 @@ class CompetitionActivity < ApplicationRecord
     !included_in_competition?
   end
 
+  def exclusion_reasons
+    return [] if included_in_competition?
+    [].tap do |reasons|
+      reasons << "private on Strava" unless INCLUDED_STRAVA_VISIBILITIES.include?(strava_data["visibility"])
+      reasons << "user excluded" unless competition_user.included_in_competition?
+      reasons << "type not included (#{strava_type})" unless competition_user.included_activity_type?(strava_type)
+      if override_activity_dates_strings.is_a?(Array) && override_activity_dates_strings.empty?
+        reasons << "manually excluded"
+      elsif !competition.in_period?(activity_dates)
+        reasons << "outside competition period"
+      end
+    end
+  end
+
   def strava_type
     strava_data["type"]
   end

--- a/app/models/competition_activity.rb
+++ b/app/models/competition_activity.rb
@@ -133,14 +133,14 @@ class CompetitionActivity < ApplicationRecord
   end
 
   def exclusion_reasons
-    [].tap do |reasons|
-      reasons << "private on Strava" unless INCLUDED_STRAVA_VISIBILITIES.include?(strava_data["visibility"])
-      reasons << "user excluded" unless competition_user.included_in_competition?
-      reasons << "type not included (#{strava_type})" unless competition_user.included_activity_type?(strava_type)
-      unless competition.in_period?(activity_dates)
-        reasons << (manually_excluded? ? "manually excluded" : "outside competition period")
-      end
+    reasons = []
+    reasons << "private on Strava" unless INCLUDED_STRAVA_VISIBILITIES.include?(strava_data["visibility"])
+    reasons << "user excluded" unless competition_user.included_in_competition?
+    reasons << "type not included (#{strava_type})" unless competition_user.included_activity_type?(strava_type)
+    unless competition.in_period?(activity_dates)
+      reasons << (manually_excluded? ? "manually excluded" : "outside competition period")
     end
+    reasons
   end
 
   def strava_type

--- a/app/models/competition_activity.rb
+++ b/app/models/competition_activity.rb
@@ -133,15 +133,12 @@ class CompetitionActivity < ApplicationRecord
   end
 
   def exclusion_reasons
-    return [] if included_in_competition?
     [].tap do |reasons|
       reasons << "private on Strava" unless INCLUDED_STRAVA_VISIBILITIES.include?(strava_data["visibility"])
       reasons << "user excluded" unless competition_user.included_in_competition?
       reasons << "type not included (#{strava_type})" unless competition_user.included_activity_type?(strava_type)
-      if override_activity_dates_strings.is_a?(Array) && override_activity_dates_strings.empty?
-        reasons << "manually excluded"
-      elsif !competition.in_period?(activity_dates)
-        reasons << "outside competition period"
+      unless competition.in_period?(activity_dates)
+        reasons << (manually_excluded? ? "manually excluded" : "outside competition period")
       end
     end
   end
@@ -187,13 +184,14 @@ class CompetitionActivity < ApplicationRecord
   end
 
   def calculated_included_in_competition
-    INCLUDED_STRAVA_VISIBILITIES.include?(strava_data["visibility"]) &&
-      competition_user.included_in_competition? &&
-      competition_user.included_activity_type?(strava_type) &&
-      competition.in_period?(activity_dates)
+    exclusion_reasons.empty?
   end
 
   private
+
+  def manually_excluded?
+    override_activity_dates_strings.is_a?(Array) && override_activity_dates_strings.empty?
+  end
 
   def calculated_activity_dates_in_period
     competition.dates_in_period(calculated_activity_dates)

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -63,7 +63,7 @@
     if ca.included_in_competition
       check_mark
     elsif show_exclusion_reason
-      ca.exclusion_reasons.to_sentence
+      tag.ul(class: "list-disc list-inside") { safe_join(ca.exclusion_reasons.map { |r| tag.li(r) }) }
     end
   end
 

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -26,7 +26,10 @@
   end
 
   table.column(sortable: "competition_user_id", label: "User") do |ca|
-    link_to(ca.competition_user.display_name, admin_competition_activities_path(search_competition_user_id: ca.competition_user_id), class: "twlink")
+    safe_join([
+      link_to(ca.competition_user.display_name, edit_admin_competition_user_path(ca.competition_user), class: "twlink"),
+      link_to("🔍", admin_competition_activities_path(search_competition_user_id: ca.competition_user_id), class: "ml-1", title: "Filter activities by this user")
+    ], " ")
   end
 
   if competition_subject.blank?

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -11,8 +11,9 @@
   </p>
 <% end %>
 
-<%# Local var because cell blocks run via instance_exec in the table component context %>
+<%# Local vars because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>
+<% show_exclusion_reason = show_exclusion_reason? %>
 
 <%= render(UI::Table::Component.new(records: @competition_activities, render_sortable: true, sticky: true)) do |table|
   table.column(sortable: "created_at", lower_right: (->(ca) { ca.id } if show_dev_info)) do |ca|
@@ -58,10 +59,12 @@
 
   table.column(label: "Type") { |ca| ca.strava_type }
 
-  table.column(sortable: "included_in_competition", label: "Included?") { |ca| check_mark if ca.included_in_competition }
-
-  if show_exclusion_reason?
-    table.column(label: "Exclusion reason") { |ca| ca.exclusion_reasons.to_sentence }
+  table.column(sortable: "included_in_competition", label: "Included?") do |ca|
+    if ca.included_in_competition
+      check_mark
+    elsif show_exclusion_reason
+      ca.exclusion_reasons.to_sentence
+    end
   end
 
   if show_dev_info

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -1,5 +1,7 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: competition_user_subject.blank?, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, period: @period, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competition_activities, time_range: @time_range, time_range_column: @time_range_column)) do %>
-  <%= link_to "exclusion reason", url_for(sortable_params.merge(search_show_exclusion_reason: !show_exclusion_reason?)), class: "twlink #{"active" if show_exclusion_reason?}" %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: competition_user_subject.blank?, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, period: @period, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competition_activities, time_range: @time_range, time_range_column: @time_range_column)) do |c| %>
+  <% c.with_extra_action do %>
+    <%= link_to "exclusion reason", url_for(sortable_params.merge(search_show_exclusion_reason: !@show_exclusion_reason)), class: "twlink #{"active" if @show_exclusion_reason}" %>
+  <% end %>
 <% end %>
 
 <% if competition_user_subject.present? %>
@@ -13,14 +15,10 @@
 
 <%# Local vars because cell blocks run via instance_exec in the table component context %>
 <% show_dev_info = display_dev_info? %>
-<% show_exclusion_reason = show_exclusion_reason? %>
+<% show_exclusion_reason = @show_exclusion_reason %>
 
 <%= render(UI::Table::Component.new(records: @competition_activities, render_sortable: true, sticky: true)) do |table|
-  table.column(sortable: "created_at", lower_right: (->(ca) { ca.id } if show_dev_info)) do |ca|
-    render(UI::Time::Component.new(time: ca.created_at))
-  end
-
-  table.column(sortable: "start_at", label: "Start") do |ca|
+  table.column(sortable: "start_at", label: "Start", lower_right: (->(ca) { ca.id } if show_dev_info)) do |ca|
     render(UI::Time::Component.new(time: ca.start_at))
   end
 
@@ -31,8 +29,8 @@
   table.column(sortable: "competition_user_id", label: "User") do |ca|
     safe_join([
       link_to(ca.competition_user.display_name, edit_admin_competition_user_path(ca.competition_user), class: "twlink"),
-      link_to("🔍", admin_competition_activities_path(search_competition_user_id: ca.competition_user_id), class: "ml-1", title: "Filter activities by this user")
-    ], " ")
+      link_to("🔍", admin_competition_activities_path(search_competition_user_id: ca.competition_user_id), title: "Filter activities by this user")
+    ], "&nbsp;".html_safe)
   end
 
   if competition_subject.blank?
@@ -65,6 +63,10 @@
     elsif show_exclusion_reason
       tag.ul(class: "list-disc list-inside") { safe_join(ca.exclusion_reasons.map { |r| tag.li(r) }) }
     end
+  end
+
+  table.column(sortable: "created_at", label: "Created") do |ca|
+    render(UI::Time::Component.new(time: ca.created_at))
   end
 
   if show_dev_info

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -29,8 +29,9 @@
   table.column(sortable: "competition_user_id", label: "User") do |ca|
     safe_join([
       link_to(ca.competition_user.display_name, edit_admin_competition_user_path(ca.competition_user), class: "twlink"),
+      "&nbsp;".html_safe,
       link_to("🔍", admin_competition_activities_path(search_competition_user_id: ca.competition_user_id), title: "Filter activities by this user")
-    ], "&nbsp;".html_safe)
+    ])
   end
 
   if competition_subject.blank?

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -1,4 +1,6 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: competition_user_subject.blank?, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, period: @period, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competition_activities, time_range: @time_range, time_range_column: @time_range_column)) %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, include_competition_select: competition_user_subject.blank?, competition_subject:, user_subject:, user_param: params[:user], searchable_competitions:, period: @period, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competition_activities, time_range: @time_range, time_range_column: @time_range_column)) do %>
+  <%= link_to "exclusion reason", url_for(sortable_params.merge(search_show_exclusion_reason: !show_exclusion_reason?)), class: "twlink #{"active" if show_exclusion_reason?}" %>
+<% end %>
 
 <% if competition_user_subject.present? %>
   <p class="mb-2">
@@ -57,6 +59,10 @@
   table.column(label: "Type") { |ca| ca.strava_type }
 
   table.column(sortable: "included_in_competition", label: "Included?") { |ca| check_mark if ca.included_in_competition }
+
+  if show_exclusion_reason?
+    table.column(label: "Exclusion reason") { |ca| ca.exclusion_reasons.to_sentence }
+  end
 
   if show_dev_info
     table.column(sortable: "updated_at") do |ca|

--- a/app/views/admin/competitions/index.html.erb
+++ b/app/views/admin/competitions/index.html.erb
@@ -1,5 +1,7 @@
-<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject:, searchable_competitions:, period: @period, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competitions, time_range: @time_range, time_range_column: @time_range_column)) do %>
-  <%= link_to "New Competition", new_admin_competition_path, class: "twlink" %>
+<%= render(Admin::CurrentHeader::Component.new(viewing: controller_name.humanize, competition_subject:, searchable_competitions:, period: @period, s_params: sortable_params, pagy: @pagy, render_chart: @render_chart, chart_collection: @matching_competitions, time_range: @time_range, time_range_column: @time_range_column)) do |c| %>
+  <% c.with_extra_action do %>
+    <%= link_to "New Competition", new_admin_competition_path, class: "twlink" %>
+  <% end %>
 <% end %>
 
 <%# Local var because cell blocks run via instance_exec in the table component context %>

--- a/spec/components/admin/current_header/component_spec.rb
+++ b/spec/components/admin/current_header/component_spec.rb
@@ -42,14 +42,16 @@ RSpec.describe Admin::CurrentHeader::Component, type: :component do
     end
   end
 
-  context "with a content block" do
+  context "with an extra_action slot" do
     let(:component) do
       with_request_url("/admin/competition_users") do
-        render_inline(instance) { "New Competition".html_safe }
+        render_inline(instance) do |c|
+          c.with_extra_action { "New Competition".html_safe }
+        end
       end
     end
 
-    it "renders the block alongside the graph toggle" do
+    it "renders the slot alongside the graph toggle" do
       expect(component.to_html).to include("New Competition")
       expect(component.css("a").map(&:text)).to include("graph")
     end

--- a/spec/models/competition_activity_spec.rb
+++ b/spec/models/competition_activity_spec.rb
@@ -225,6 +225,53 @@ RSpec.describe CompetitionActivity, type: :model do
     end
   end
 
+  describe "exclusion_reasons" do
+    let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2024-5-1")) }
+    let(:competition_user) { FactoryBot.create(:competition_user, competition:) }
+    let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:) }
+
+    it "is empty when included" do
+      expect(competition_activity.included_in_competition?).to be_truthy
+      expect(competition_activity.exclusion_reasons).to eq([])
+    end
+
+    context "with private visibility" do
+      let(:competition_activity) do
+        FactoryBot.create(:competition_activity, competition_user:).tap do |ca|
+          ca.update(strava_data: ca.strava_data.merge("visibility" => "only_me"))
+        end
+      end
+
+      it "lists private" do
+        expect(competition_activity.exclusion_reasons).to eq(["private on Strava"])
+      end
+    end
+
+    context "with disallowed activity type" do
+      let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:, strava_type: "Skydive") }
+
+      it "lists type" do
+        expect(competition_activity.exclusion_reasons).to eq(["type not included (Skydive)"])
+      end
+    end
+
+    context "with manually excluded override_activity_dates_strings" do
+      let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:, override_activity_dates_strings: []) }
+
+      it "lists manually excluded" do
+        expect(competition_activity.exclusion_reasons).to eq(["manually excluded"])
+      end
+    end
+
+    context "with activity outside competition period" do
+      let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:, override_activity_dates_strings: ["2023-04-01"]) }
+
+      it "lists outside competition period" do
+        expect(competition_activity.exclusion_reasons).to eq(["outside competition period"])
+      end
+    end
+  end
+
   describe "manual_entry?" do
     let(:competition) { FactoryBot.create(:competition, start_date: Time.parse("2024-05-01")) }
     let(:competition_user) { FactoryBot.create(:competition_user, competition:) }

--- a/spec/models/competition_activity_spec.rb
+++ b/spec/models/competition_activity_spec.rb
@@ -228,17 +228,18 @@ RSpec.describe CompetitionActivity, type: :model do
   describe "exclusion_reasons" do
     let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2024-5-1")) }
     let(:competition_user) { FactoryBot.create(:competition_user, competition:) }
-    let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:) }
+    let(:overrides) { {} }
+    let(:competition_activity) { FactoryBot.build(:competition_activity, competition_user:, **overrides).tap(&:valid?) }
 
     it "is empty when included" do
-      expect(competition_activity.included_in_competition?).to be_truthy
       expect(competition_activity.exclusion_reasons).to eq([])
     end
 
     context "with private visibility" do
       let(:competition_activity) do
-        FactoryBot.create(:competition_activity, competition_user:).tap do |ca|
-          ca.update(strava_data: ca.strava_data.merge("visibility" => "only_me"))
+        FactoryBot.build(:competition_activity, competition_user:).tap do |ca|
+          ca.strava_data = ca.strava_data.merge("visibility" => "only_me")
+          ca.valid?
         end
       end
 
@@ -248,7 +249,7 @@ RSpec.describe CompetitionActivity, type: :model do
     end
 
     context "with disallowed activity type" do
-      let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:, strava_type: "Skydive") }
+      let(:overrides) { {strava_type: "Skydive"} }
 
       it "lists type" do
         expect(competition_activity.exclusion_reasons).to eq(["type not included (Skydive)"])
@@ -256,7 +257,7 @@ RSpec.describe CompetitionActivity, type: :model do
     end
 
     context "with manually excluded override_activity_dates_strings" do
-      let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:, override_activity_dates_strings: []) }
+      let(:overrides) { {override_activity_dates_strings: []} }
 
       it "lists manually excluded" do
         expect(competition_activity.exclusion_reasons).to eq(["manually excluded"])
@@ -264,7 +265,7 @@ RSpec.describe CompetitionActivity, type: :model do
     end
 
     context "with activity outside competition period" do
-      let(:competition_activity) { FactoryBot.create(:competition_activity, competition_user:, override_activity_dates_strings: ["2023-04-01"]) }
+      let(:overrides) { {override_activity_dates_strings: ["2023-04-01"]} }
 
       it "lists outside competition period" do
         expect(competition_activity.exclusion_reasons).to eq(["outside competition period"])

--- a/spec/requests/admin/competition_activities_request_spec.rb
+++ b/spec/requests/admin/competition_activities_request_spec.rb
@@ -77,16 +77,20 @@ RSpec.describe base_url, type: :request do
       end
 
       describe "show_exclusion_reason toggle" do
+        let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2024-05-01")) }
+        let(:competition_user) { FactoryBot.create(:competition_user, competition:) }
+        let!(:excluded_activity) { FactoryBot.create(:competition_activity, competition_user:, strava_type: "Skydive") }
+
         it "is off by default and toggle link points to true" do
-          get base_url
+          get "#{base_url}?search_competition_id=#{competition.id}"
           expect(response.body).to include("search_show_exclusion_reason=true")
-          expect(response.body).not_to include("Exclusion reason")
+          expect(response.body).not_to include("type not included")
         end
 
         it "is on with search_show_exclusion_reason=true" do
-          get "#{base_url}?search_show_exclusion_reason=true"
+          get "#{base_url}?search_competition_id=#{competition.id}&search_show_exclusion_reason=true"
           expect(response.body).to include("search_show_exclusion_reason=false")
-          expect(response.body).to include("Exclusion reason")
+          expect(response.body).to include("type not included (Skydive)")
         end
       end
     end

--- a/spec/requests/admin/competition_activities_request_spec.rb
+++ b/spec/requests/admin/competition_activities_request_spec.rb
@@ -75,6 +75,20 @@ RSpec.describe base_url, type: :request do
           expect(assigns(:competition_activities).pluck(:id)).to eq([activity1.id])
         end
       end
+
+      describe "show_exclusion_reason toggle" do
+        it "is off by default and toggle link points to true" do
+          get base_url
+          expect(response.body).to include("search_show_exclusion_reason=true")
+          expect(response.body).not_to include("Exclusion reason")
+        end
+
+        it "is on with search_show_exclusion_reason=true" do
+          get "#{base_url}?search_show_exclusion_reason=true"
+          expect(response.body).to include("search_show_exclusion_reason=false")
+          expect(response.body).to include("Exclusion reason")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- "User" column on the admin competition activities table now links the display name to the competition user's edit page; a 🔍 link beside it filters activities to that user (the previous click behavior).
- New "exclusion reason" toggle next to the graph link, gated by `?search_show_exclusion_reason=true`, replaces the empty "Included?" cell on excluded rows with a bulleted list of reasons (private, user excluded, type, manually excluded, outside competition period).

## Screenshots

### /admin/competition_activities

| Desktop | Mobile |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/2a853b03-ed61-4c8f-8bdb-62ad85604562" width="600"> | <img src="https://github.com/user-attachments/assets/f3e4aad8-b78b-4369-a907-9179b0c5d842" width="300"> |

### /admin/competition_activities?search_show_exclusion_reason=true

<img width="800" alt="exclusion-reason-on" src="https://github.com/user-attachments/assets/d15a41ee-2635-4c5b-bc84-83dbea0e7010" />
