### PR TITLE
Dedupe competition_activities by strava_id in find_or_create_if_valid

### DIFF
--- a/app/models/competition_activity.rb
+++ b/app/models/competition_activity.rb
@@ -45,7 +45,7 @@ class CompetitionActivity < ApplicationRecord
 
   class << self
     def find_by_strava_data(strava_data)
-      find_by(strava_id: strava_data["id"])
+      where(strava_id: strava_data["id"].to_s).order(:id).first
     end
 
     # dates_strings must be an array of dates that are strings
@@ -56,6 +56,7 @@ class CompetitionActivity < ApplicationRecord
     def find_or_create_if_valid(competition_user:, strava_data:)
       competition_activity = find_by_strava_data(strava_data)
       if competition_activity.present?
+        where(strava_id: competition_activity.strava_id).where.not(id: competition_activity.id).destroy_all
         update_competition_activity_if_changed(strava_data:, competition_activity:)
       else
         create(competition_user:, strava_data:)

--- a/app/models/competition_activity.rb
+++ b/app/models/competition_activity.rb
@@ -56,7 +56,7 @@ class CompetitionActivity < ApplicationRecord
     def find_or_create_if_valid(competition_user:, strava_data:)
       competition_activity = find_by_strava_data(strava_data)
       if competition_activity.present?
-        where(strava_id: competition_activity.strava_id).where.not(id: competition_activity.id).destroy_all
+        where(strava_id: competition_activity.strava_id).where("id > ?", competition_activity.id).destroy_all
         update_competition_activity_if_changed(strava_data:, competition_activity:)
       else
         create(competition_user:, strava_data:)

--- a/spec/jobs/update_competition_user_job_spec.rb
+++ b/spec/jobs/update_competition_user_job_spec.rb
@@ -111,6 +111,27 @@ RSpec.describe UpdateCompetitionUserJob, type: :job do
       end
     end
 
+    context "with a duplicate competition_activity" do
+      let!(:original) do
+        FactoryBot.create(:competition_activity, competition_user:, strava_id: "11319708328",
+          start_at: Time.parse("2024-05-03T02:59:12Z"))
+      end
+      let!(:duplicate) do
+        FactoryBot.create(:competition_activity, competition_user:, strava_id: "11319708328",
+          start_at: Time.parse("2024-05-03T02:59:12Z"))
+      end
+
+      it "deletes the duplicate with the higher id" do
+        expect(duplicate.id).to be > original.id
+        VCR.use_cassette("update_competition_user_job", match_requests_on: [:path]) do
+          instance.perform(competition_user.id)
+        end
+        expect(CompetitionActivity.where(id: duplicate.id)).to be_empty
+        expect(CompetitionActivity.where(id: original.id)).to be_present
+        expect(competition_user.reload.competition_activities.count).to eq 3
+      end
+    end
+
     context "data changes slightly" do
       let(:time) { Time.current - 5.minutes }
       it "doesn't update" do


### PR DESCRIPTION
`CompetitionActivity.find_or_create_if_valid` now destroys any extra rows sharing the same `strava_id` (keeping the lowest-id row) before updating, so re-syncing a user clears out duplicates that snuck in. `find_by_strava_data` orders by `id` to make the kept row deterministic.

Adds a `update_competition_user_job` spec that seeds two activities with the same `strava_id` and asserts the higher-id duplicate is destroyed when the job runs.
