### PR TITLE
UI::Button: drop underline; tighten PeriodSelect on mobile

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -80,7 +80,9 @@ From the changed files, infer the affected routes. Heuristics:
 - Admin views → `/admin/...`
 - If unclear, ask the user which URLs to capture before proceeding. Do not guess blindly — 1–3 well-chosen URLs beats 10 random ones.
 
-If `bin/dev` isn't already up (`curl -fs "$BASE_URL/" >/dev/null` fails), start it in the background — Tailwind and JS need to compile before screenshots will render correctly. Then poll the same `curl` until it succeeds.
+**Never start or stop `bin/dev` for the user.** The dev server is the user's process. Starting your own copy can land you on a different DB; stopping theirs interrupts work.
+
+Check whether the dev server is up: `curl -fs "$BASE_URL/" >/dev/null`. If it isn't, **stop and ask the user to start it** (`bin/dev` from their own terminal), then resume once they confirm. Do not background-launch it yourself, even temporarily.
 
 ### 5. Capture screenshots
 

--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -27,13 +27,46 @@ Fix every failing test, even ones that were already failing on `main`. Confirmin
 
 ## Don't weaken assertions to make a failing test pass
 
-When a test goes red, the default move is **investigate why**, not edit the assertion to match the new output. Watch for these tempting "fixes" that are actually erasing signal:
+When a test goes red, the correct move is **investigate why**, not edit the assertion to match the new output. Watch for these tempting "fixes" that are actually erasing signal:
 
 - Changing an expected value to whatever the page/chart/response now happens to render (e.g. `0` → `null`, an exact count → a range, a specific string → a substring/regex).
 - Loosening `eq` to `include`, dropping `count:` constraints, or replacing `expect(...).to ...` with `expect(...).not_to be_nil`.
 - Deleting the assertion entirely with a "looks unrelated" handwave.
 
 The right loop: reproduce the failure, figure out *what* changed and *why*, then decide intentionally — fix the code if the original assertion captured the right behavior, or update the assertion (with a comment) if the behavior intentionally changed. If you're about to change a test "to make it easier", stop and explain why the new expectation is correct, not just convenient.
+
+## Match a target attributes hash, not one attribute at a time
+
+When you're checking several fields on the same object or response, build one expected-attributes hash and assert against it in a single matcher. Don't write a chain of one-attribute-per-line `expect`s.
+
+- Object (ActiveRecord, plain Ruby): `expect(record).to have_attributes(target_attributes)`
+- Hash (JSON response, parsed body): `expect(hash).to eq(target.as_json)` for full match, or `expect(hash).to include(target_attributes)` for partial.
+
+This collapses what would be 4 brittle assertions into 1, makes the *contract* visible at a glance, and gives a single readable diff when something changes. It also avoids the trap of weak per-field assertions like `expect(x).to be_present` or `expect(url).not_to include("blank.png")` standing in for "the right value" — match the value directly.
+
+### Good
+
+```ruby
+target_attributes = {kind: "found", impounded_description: "Some description"}
+expect(impound_record).to have_attributes(target_attributes)
+
+expect(json_result["memberships"]).to eq([target_membership.as_json])
+```
+
+### Bad
+
+```ruby
+expect(impound_record.kind).to eq("found")
+expect(impound_record.impounded_description).to be_present
+expect(impound_record.impounded_description).to eq("Some description")
+
+logo_url = json_result["memberships"].first["organization_logo_url"]
+expect(logo_url).to be_present
+expect(logo_url).not_to include("blank.png")
+expect(logo_url).to eq(organization.avatar_url)
+```
+
+The bad version spreads one logical assertion across many lines, mixes weak presence checks with the real expected value, and produces noisier failure output.
 
 ## Structuring with `context` and `let`
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -146,6 +146,11 @@
     font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 focus:outline-none;
 }
 
+/* Unlayered so it wins over the size utilities (`px-2.5`) injected by UI::Button */
+.period-select-standard {
+  @apply px-1.5 sm:px-2.5;
+}
+
 /* Side utilities so the borders can be re-applied in JS when columns are hidden */
 @utility ui-table-bordered-td-first {
   @apply border-l border-purple-200 dark:border-purple-700;

--- a/app/components/ui/alert/component.rb
+++ b/app/components/ui/alert/component.rb
@@ -42,10 +42,6 @@ module UI
         TEXT_CLASSES[@kind]
       end
 
-      def text_color_classes_important
-        text_color_classes.gsub("00", "00!")
-      end
-
       def dismissable_color_classes
         case @kind
         when :notice

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -31,7 +31,7 @@ module UI
         classes = [BASE_CLASSES, COLORS[color], html_class]
         unless color == :link
           classes << SIZES[size]
-          classes << "focus:outline-none focus:ring-3 font-medium"
+          classes << "focus:outline-none focus:ring-3 font-medium no-underline"
         end
         classes << ACTIVE_COLORS[color] if active
         classes.compact.join(" ")

--- a/app/components/ui/chart/component.rb
+++ b/app/components/ui/chart/component.rb
@@ -70,7 +70,15 @@ module UI
       end
 
       def call
-        helpers.column_chart @series, stacked: @stacked, thousands: @thousands, colors: @colors
+        helpers.column_chart @series, stacked: @stacked, thousands: @thousands, colors: chart_colors
+      end
+
+      private
+
+      # Chartkick paints single-series column bars per-color from a flat array;
+      # collapse to one so bars are uniform.
+      def chart_colors
+        @series.is_a?(Hash) ? [@colors.first] : @colors
       end
     end
   end

--- a/app/components/ui/dropdown/component.html.erb
+++ b/app/components/ui/dropdown/component.html.erb
@@ -1,4 +1,8 @@
-<div class="relative inline-block" data-controller="ui--dropdown">
+<div
+  class="relative inline-block"
+  data-controller="ui--dropdown"
+  data-ui--dropdown-placement-value="<%= floating_ui_placement %>"
+>
   <button
     type="button"
     class="<%= button_classes %>"
@@ -21,7 +25,6 @@
       border-purple-200 dark:border-purple-700 min-w-44 z-50
     "
     data-ui--dropdown-target="menu"
-    data-ui--dropdown-placement-value="<%= floating_ui_placement %>"
   >
     <ul role="menu" class="dropdown-menu" aria-labelledby="<%= button_id %>">
       <% entries.each do |entry| %>

--- a/app/components/ui/period_select/component.html.erb
+++ b/app/components/ui/period_select/component.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="ui--period-select collapse">
   <div
     id="timeSelectionBtnGroup"
-    class="flex flex-wrap justify-end gap-2 <%= "custom-period-selected" if @period == "custom" %>"
+    class="flex flex-wrap justify-end gap-1 sm:gap-2 <%= "custom-period-selected" if @period == "custom" %>"
     role="group"
   >
     <% if @prepend_text.present? %>
@@ -26,6 +26,7 @@
       text: "custom",
       size: :sm,
       active: @period == "custom",
+      html_class: "period-select-standard",
       data: {period: "custom", action: "click->collapse#toggle"}
     ) %>
   </div>

--- a/app/components/ui/period_select/component.rb
+++ b/app/components/ui/period_select/component.rb
@@ -49,7 +49,7 @@ module UI
           size: :sm,
           active: @period == period_key,
           class: "period-select-standard",
-          data: {period: period_key}
+          data: {period: period_key, turbo_action: "advance"}
         )
       end
 


### PR DESCRIPTION
Two small UI component fixes mirrored from bikeindex/bike_index#3495:

- `UI::Button` non-link variants now include `no-underline`, so `UI::ButtonLink` (renders `<a>`) doesn't pick up any global/default underline-on-hover.
- `UI::PeriodSelect` tightens spacing on mobile so the seven period buttons fit on one line at 375px instead of wrapping `custom`. The container drops to `gap-1` below `sm`, and the new `.period-select-standard` class (now applied to the custom button too) is defined unlayered so its `px-1.5 sm:px-2.5` wins over the `px-2.5` that `UI::Button::SIZES[:sm]` injects from `@layer utilities`.

## Screenshots

### Lookbook `UI::PeriodSelect` variants

| Desktop (1440px) | Mobile (390px) |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/c078dae3-f096-4dc6-ba49-7188aa8b5c44" width="600"> | <img src="https://github.com/user-attachments/assets/d812acf8-6ad8-45eb-aa42-9aa3a54bd70b" width="300"> |
