### PR TITLE
twtext-color utility; port modal/tooltip tweaks from bike_index#3505

### DIFF
--- a/.claude/skills/production-log-inspection/SKILL.md
+++ b/.claude/skills/production-log-inspection/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: production-log-inspection
+description: >-
+  Inspect the May is Bike Month production Rails log at `tmp/production.log` —
+  JSON-per-request format produced by Lograge, far too large to read
+  end-to-end. Trigger when the user asks to
+  review, investigate, audit, or pull stats from a production log file
+  (slow requests, error spikes, status-code distribution, exception
+  stack traces, per-endpoint hit counts, suspicious traffic). Also
+  triggers when chasing a specific incident from logs (e.g. "what
+  happened at 04:42 UTC?", "why did `/competitions/2026` 500?").
+  Honeybadger MCP is the right tool for *aggregated* exception triage
+  across time; this skill is for ad-hoc analysis of a specific log
+  file already on disk.
+---
+
+# Inspecting production logs
+
+The May is Bike Month production log lives at `tmp/production.log`. It's large, so:
+
+- **Never `Read` or `cat` the whole file.** Use `grep`/`awk`/`head`/`tail` to slice.
+- **Synthesize by default; paste at most one short example when it's load-bearing.** Lograge lines are long and mostly structural JSON — dumping multiple into a reply is unreadable and burns context. A single representative line for an exception or a slow request is fine; a wall of grep output is not.
+
+## Log line format
+
+Each request produces one JSON-content line (Lograge), prefixed by a syslog-style header:
+
+```
+I, [2026-04-27T04:42:04.467657 #277641]  INFO -- : [0591f694-…] {"method":"GET","path":"/competitions/2026","format":"html","controller":"CompetitionsController","action":"show","status":500,"allocations":1073409,"duration":51237.65,"view":0.0,"db":51234.09,"remote_ip":"71.212.12.114","u_id":148942,"params":{…},"@timestamp":"…","@version":"1","message":"…"}
+```
+
+Key fields:
+
+| Field | Notes |
+|---|---|
+| `duration`, `view`, `db` | **Milliseconds.** A 60s query is `60000`, not `60`. |
+| `status` | HTTP status code |
+| `controller`, `action`, `path` | Routing info |
+| `u_id` | User id (null for anonymous) |
+| `remote_ip` | Forwarded client IP |
+| `allocations` | Ruby object allocations — high allocations + long duration is a strong signal of a bad query plan |
+| `params` | Object literal — may contain commas/colons; don't split lines on `,` |
+
+When a request raises, you also get **separate, non-JSON lines** with the same request id prefix containing the exception class, message, and stack trace, *followed* by another JSON line for `/500` (the `ErrorsController#server_error` render). That secondary `/500` line is noise for most analyses — it inflates 500 counts unless you filter it out.
+
+## Common queries
+
+**Time range covered.**
+
+```bash
+head -1 tmp/production.log
+tail -1 tmp/production.log
+```
+
+**Status-code distribution.**
+
+```bash
+grep -oE '"status":[0-9]+' tmp/production.log | sort | uniq -c | sort -rn
+```
+
+**Slow requests over a threshold (in ms).** Use `awk` rather than a regex — durations are floats with arbitrary digit counts and a regex like `"duration":[5-9][0-9]{4}` will silently miss values:
+
+```bash
+awk -F'"duration":' '$2 != "" {split($2,a,","); if (a[1]+0 > 60000) print}' tmp/production.log
+```
+
+Pipe that into `grep -oE '"path":"[^"]+"' | sort | uniq -c | sort -rn` to group by path, or `grep -oE '"status":[0-9]+'` for status mix.
+
+**Distribution stats (p50/p90/p99).**
+
+```bash
+awk -F'"duration":' '$2 != "" {split($2,a,","); print a[1]+0}' tmp/production.log \
+  | sort -n \
+  | awk 'BEGIN{c=0}{v[c++]=$1; s+=$1} END{print "n="c, "p50="v[int(c*.5)], "p90="v[int(c*.9)], "p99="v[int(c*.99)], "max="v[c-1], "mean="s/c}'
+```
+
+**Most-hit endpoints.**
+
+```bash
+grep -oE '"controller":"[^"]+","action":"[^"]+"' tmp/production.log | sort | uniq -c | sort -rn | head -20
+```
+
+**5xx counts by endpoint.** Filter to `"status":5` first to keep the line set small:
+
+```bash
+grep '"status":5' tmp/production.log \
+  | grep -oE '"controller":"[^"]+","action":"[^"]+"' | sort | uniq -c | sort -rn
+```
+
+## Finding exception stack traces
+
+The JSON request line tells you a request 500'd but not *why*. Grab the request id from the JSON line, then `grep -n` the whole file for that id — Rails writes the exception class and backtrace as separate lines with the same `[request-id]` prefix:
+
+```bash
+grep -n "0591f694-49b4-4c9c-b49e-4fef89ae8d7b" tmp/production.log
+```
+
+Look for lines starting with `E,` (ERROR severity) and lines beginning `[<id>] ActiveRecord::…` / `[<id>] ActionView::…` / `[<id>] Caused by:` / `[<id>] app/…:NN`. The trailing `app/…` lines are the user-code frames (Rails strips gem frames by default).
+
+To find clusters of the same exception, search for the exception class plus a line of context:
+
+```bash
+grep -B0 -A1 "PG::TRSerializationFailure" tmp/production.log | head -40
+```
+
+## Pitfalls
+
+- **Each errored request creates ≥2 JSON lines** — the original + the rendered `/500` page. Counting `"status":500` over-counts unless you exclude `"controller":"ErrorsController"` or filter to one of them.
+- **`grep | sort | uniq` on JSON fragments is fine for counting**, but don't `awk -F,` or `cut -d,` on a whole line — `params:{…}` contains commas. Anchor splits to the field name (`-F'"duration":'`).
+- **Durations are ms**, not seconds. A "slow" search is `> 60000`, not `> 60`.
+- **The replication-conflict cancel error** (`PG::TRSerializationFailure: canceling statement due to conflict with recovery`) means the *replica* killed the query because WAL recovery was blocked — it's a symptom of a slow query holding the replica too long, not a bug in the SQL itself. Look for the underlying duration to find the real cause.
+- **Bots and scanners produce a lot of noise** in 4xx and 5xx counts (path-traversal probes, `.well-known/*` lookups, npm CDN-style 404s). Eyeball the path before treating an error spike as a real issue.
+- **The Bash tool truncates long lines in piped output** with `[... omitted end of long line]`, even when the pipeline ends in a file redirect. Fields at the *end* of a Lograge JSON line (`@timestamp`, `@version`, `message`) get clipped if you stage with `grep <line-pattern> | grep -oE '<trailing-field>'`. Workarounds: (a) `awk` directly on the file — no pipe, full lines preserved; (b) `grep -oE '<pattern>' file.log` so the *match* itself (short) is what enters the pipeline, not the whole line.
+- **One scanner IP can dominate counts.** A single bot can rack up tens of thousands of 4xx/5xx and make a real user-facing issue look bigger than it is. Always check `"remote_ip"` distribution before treating an error spike as a real signal — group by IP first, then re-run analyses excluding the dominant scanner.
+
+## When `jq` is and isn't worth it
+
+The lines are JSON, so `jq` is tempting — but you have to strip the syslog prefix first, and on a full-day log it's noticeably slower than `grep`/`awk`. Use `jq` when you need to group by **two or more** JSON fields at once, or when params/payload structure matters; otherwise `awk -F'"key":'` patterns above are faster.
+
+```bash
+# strip prefix, then jq — only worth it for multi-field aggregations
+sed -E 's/^[^{]+//' tmp/production.log \
+  | jq -r 'select(.status==500) | "\(.controller)#\(.action)\t\(.duration)"' \
+  | sort | uniq -c | sort -rn | head
+```
+
+## Honeybadger vs. log files
+
+For "what's currently broken in production" or "is exception X happening more this week", Honeybadger MCP (`mcp__honeybadger__list_faults`, `get_fault`, `query_insights`) is the right tool — it has aggregation, dedup, and time-series. Reach for this skill when:
+
+- The user has already downloaded or pointed you at a specific log file, or
+- The question is about *requests that didn't raise* (slow successful queries, traffic patterns, status-code mix), which Honeybadger doesn't capture.

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -22,7 +22,7 @@
     box-sizing: border-box;
   }
   body {
-    @apply bg-purple-0 dark:bg-purple-900 text-purple-900 dark:text-purple-0 font-sans antialiased text-[13px] leading-[1.45];
+    @apply bg-purple-0 dark:bg-purple-900 twtext-color font-sans antialiased text-[13px] leading-[1.45];
   }
   h1 {
     @apply text-2xl;
@@ -46,6 +46,10 @@
 }
 .wrapper-padding-overflow {
   @apply md:px-7 md:-mx-7 px-4 -mx-4;
+}
+
+@utility twtext-color {
+  @apply text-purple-900 dark:text-purple-0;
 }
 
 @layer components {
@@ -167,7 +171,7 @@
   @apply text-sm font-medium text-gray-700 dark:text-gray-300 mb-1;
 }
 .hw-combobox__chip {
-  @apply font-mono text-purple-900 dark:text-purple-0 bg-purple-100 dark:bg-purple-700;
+  @apply font-mono twtext-color bg-purple-100 dark:bg-purple-700;
 }
 .hw-combobox {
   min-width: 280px;

--- a/app/components/competition_history/component.html.erb
+++ b/app/components/competition_history/component.html.erb
@@ -76,12 +76,7 @@
           <% top_placings.each do |competition_user| %>
             <td class="<%= placing_cell_class %>">
               <% if competition_user %>
-                <div
-                  class="
-                    twtext-color font-medium
-                    text-[13px] truncate max-w-36
-                  "
-                >
+                <div class="twtext-color font-medium text-[13px] truncate max-w-36">
                   <%= competition_user.display_name %>
                 </div>
                 <div class="<%= sub_class %> mt-0.5">
@@ -175,12 +170,7 @@
 
           <td class="<%= placing_cell_class %>">
             <% if row.last_place %>
-              <div
-                class="
-                  twtext-color font-medium text-[13px]
-                  truncate max-w-36
-                "
-              >
+              <div class="twtext-color font-medium text-[13px] truncate max-w-36">
                 <%= row.last_place.display_name %>
               </div>
               <div class="<%= sub_class %> mt-0.5">

--- a/app/components/competition_history/component.html.erb
+++ b/app/components/competition_history/component.html.erb
@@ -1,4 +1,4 @@
-<% num_class = "font-mono text-[13px] font-medium text-purple-900 dark:text-purple-0 tabular-nums" %>
+<% num_class = "font-mono text-[13px] font-medium twtext-color tabular-nums" %>
 <% sub_class = "font-mono text-[11px] text-purple-400 dark:text-purple-300 tabular-nums" %>
 <% head_class = "w-36 min-w-36 text-purple-300 dark:text-purple-400 text-[10px] uppercase tracking-[0.12em] font-medium whitespace-nowrap border-x border-purple-200 dark:border-purple-600" %>
 <% selected_head_class = "#{head_class} bg-purple-200/70 dark:bg-purple-700" %>
@@ -60,12 +60,7 @@
         <tr class="odd:bg-purple-50/60 dark:odd:bg-purple-800/40">
           <td class="<%= cell_class %> whitespace-nowrap">
             <%= link_to competition_path(row.slug), class: "block no-underline" do %>
-              <div
-                class="
-                  font-mono font-medium text-[20px] text-purple-900
-                  dark:text-purple-0 leading-none
-                "
-              >
+              <div class="font-mono font-medium text-[20px] twtext-color leading-none">
                 <%= row.year %>
               </div>
 
@@ -83,7 +78,7 @@
               <% if competition_user %>
                 <div
                   class="
-                    text-purple-900 dark:text-purple-0 font-medium
+                    twtext-color font-medium
                     text-[13px] truncate max-w-36
                   "
                 >
@@ -123,7 +118,7 @@
             <td class="<%= selected_cell_class %>">
               <% if competition_user %>
                 <% position = row.position_in_table(competition_user) %>
-                <div class="text-purple-900 dark:text-purple-0 font-medium text-[13px]">
+                <div class="twtext-color font-medium text-[13px]">
                   #<%= number_display(competition_user.rank_in_competition) %>
                 </div>
                 <% if position == :first || position == :second %>
@@ -182,7 +177,7 @@
             <% if row.last_place %>
               <div
                 class="
-                  text-purple-900 dark:text-purple-0 font-medium text-[13px]
+                  twtext-color font-medium text-[13px]
                   truncate max-w-36
                 "
               >

--- a/app/components/leaderboard/legacy_competition_user_row/component.html.erb
+++ b/app/components/leaderboard/legacy_competition_user_row/component.html.erb
@@ -27,7 +27,7 @@
         <button
           type="button"
           class="
-            text-purple-900 dark:text-purple-0 font-medium text-left truncate
+            twtext-color font-medium text-left truncate
             cursor-pointer outline-none underline decoration-1
             decoration-transparent hover:decoration-current
             aria-pressed:decoration-current aria-pressed:decoration-2
@@ -41,7 +41,7 @@
           <%= @competition_user.display_name %>
         </button>
       <% else %>
-        <span class="text-purple-900 dark:text-purple-0 font-medium truncate">
+        <span class="twtext-color font-medium truncate">
           <%= @competition_user.display_name %>
         </span>
       <% end %>
@@ -84,7 +84,7 @@
         max-lg:col-start-3 max-lg:row-start-1
       "
     >
-      <span class="text-purple-900 dark:text-purple-0 text-[16px] font-medium">
+      <span class="twtext-color text-[16px] font-medium">
         <span class="unit-imperial">
           <%= number_display(meters_to_miles(@competition_user.distance_meters), round_to: 1) %>
           mi

--- a/app/components/leaderboard/punchcard_user_row/component.html.erb
+++ b/app/components/leaderboard/punchcard_user_row/component.html.erb
@@ -33,7 +33,7 @@
         <button
           type="button"
           class="
-            text-purple-900 dark:text-purple-0 font-medium text-left
+            twtext-color font-medium text-left
             cursor-pointer outline-none underline decoration-1
             decoration-transparent hover:decoration-current
             aria-pressed:decoration-current aria-pressed:decoration-2
@@ -75,7 +75,7 @@
         max-lg:col-start-1 max-lg:row-start-2 max-lg:text-left
       "
     >
-      <span class="text-purple-900 dark:text-purple-0 text-[18px] font-medium">
+      <span class="twtext-color text-[18px] font-medium">
         <b class="text-purple-500 dark:text-purple-400 font-bold">
           <%= days_count %>
         </b><span class="opacity-40">/<%= days_so_far %></span>

--- a/app/components/ui/modal/component.html.erb
+++ b/app/components/ui/modal/component.html.erb
@@ -49,7 +49,7 @@
       </div>
     <% end %>
 
-    <div class="px-5 py-4">
+    <div class="twtext-color px-5 py-4">
       <%= body %>
     </div>
   </div>

--- a/app/components/ui/modal/component_preview/default.html.erb
+++ b/app/components/ui/modal/component_preview/default.html.erb
@@ -12,7 +12,7 @@
 
 <%= render(UI::Modal::Component.new(title: "Confirmation", id: "confirm-modal")) do |modal| %>
   <% modal.with_body do %>
-    <p class="text-gray-700 dark:text-gray-300 mb-4">
+    <p class="mb-4">
       Are you sure you want to proceed?
     </p>
 

--- a/app/components/ui/tooltip/component.rb
+++ b/app/components/ui/tooltip/component.rb
@@ -10,7 +10,10 @@ module UI
         "focus-visible:ring-purple-400"
 
       renders_one :body
-      renders_one :tooltip_button, ->(**attrs) { tag.button(**trigger_attrs(**attrs)) { tooltip_span } }
+      renders_one :tooltip_button, ->(**attrs, &block) {
+        inner = block ? safe_join([capture(&block), tooltip_span], " ") : tooltip_span
+        tag.button(**trigger_attrs(**attrs)) { inner }
+      }
 
       def initialize(text: nil)
         @text = text
@@ -19,7 +22,7 @@ module UI
       def call
         return tooltip_button if tooltip_button?
 
-        tag.button(**trigger_attrs(class: TRIGGER_CLASS)) { safe_join([content, tooltip_span]) }
+        tag.button(**trigger_attrs(class: TRIGGER_CLASS)) { safe_join([content, tooltip_span], " ") }
       end
 
       private


### PR DESCRIPTION
Backports the non-color updates from bikeindex/bike_index#3505 and introduces a `twtext-color` utility that captures the body's text color so it can be reused without re-inlining the dark-mode pair.

- New `@utility twtext-color` (`text-purple-900 dark:text-purple-0`). Body now applies it; replaced inline pairs across `competition_history`, leaderboard rows, the modal body wrapper, and `.hw-combobox__chip`.
- `UI::Modal` body wrapper adopts `twtext-color` so modal content matches the page's text color; preview drops a redundant gray override.
- `UI::Tooltip` `tooltip_button` slot accepts a block to wrap the button content; `def call` uses `safe_join([...], " ")` for consistent spacing between trigger content and tooltip span.
