### PR TITLE
Keep today as an upcoming day until daily distance is met

### DIFF
--- a/app/components/leaderboard/punchcard_user_punch/component.rb
+++ b/app/components/leaderboard/punchcard_user_punch/component.rb
@@ -61,7 +61,10 @@ module Leaderboard
       end
 
       def tooltip_text
-        "#{Date.parse(@date_string).strftime("%b %-d")}: #{level ? "#{miles.round(1)} mi" : "no rides"}"
+        date_label = Date.parse(@date_string).strftime("%b %-d")
+        return "#{date_label}: #{miles.round(1)} mi" if level
+        threshold_miles = meters_to_miles(@competition.daily_distance_requirement).round
+        "#{date_label}: didn't ride #{threshold_miles} miles"
       end
     end
   end

--- a/app/components/leaderboard/punchcard_user_punch/component.rb
+++ b/app/components/leaderboard/punchcard_user_punch/component.rb
@@ -15,7 +15,8 @@ module Leaderboard
       def call
         return tag.span if @upcoming
 
-        render(UI::Tooltip::Component.new(text: tooltip_text)) do |tooltip|
+        render(UI::Tooltip::Component.new(text: tooltip_imperial)) do |tooltip|
+          tooltip.with_body { tooltip_body }
           tooltip.with_tooltip_button(**button_attrs)
         end
       end
@@ -60,11 +61,27 @@ module Leaderboard
         miles >= 100
       end
 
-      def tooltip_text
-        date_label = Date.parse(@date_string).strftime("%b %-d")
+      def tooltip_body
+        safe_join([
+          tag.span(tooltip_imperial, class: "unit-imperial"),
+          tag.span(tooltip_metric, class: "unit-metric hidden")
+        ])
+      end
+
+      def tooltip_imperial
         return "#{date_label}: #{miles.round(1)} mi" if level
-        threshold_miles = meters_to_miles(@competition.daily_distance_requirement).round
-        "#{date_label}: didn't ride #{threshold_miles} miles"
+        threshold = meters_to_miles(@competition.daily_distance_requirement).round
+        "#{date_label}: didn't ride #{threshold} miles"
+      end
+
+      def tooltip_metric
+        return "#{date_label}: #{(@distance_meters / 1000.0).round(1)} km" if level
+        threshold = (@competition.daily_distance_requirement / 1000.0).round
+        "#{date_label}: didn't ride #{threshold} km"
+      end
+
+      def date_label
+        @date_label ||= Date.parse(@date_string).strftime("%b %-d")
       end
     end
   end

--- a/app/components/leaderboard/punchcard_user_punch/component.rb
+++ b/app/components/leaderboard/punchcard_user_punch/component.rb
@@ -69,9 +69,12 @@ module Leaderboard
       end
 
       def tooltip_imperial
-        return "#{date_label}: #{miles.round(1)} mi" if level
-        threshold = meters_to_miles(@competition.daily_distance_requirement).round
-        "#{date_label}: didn't ride #{threshold} miles"
+        @tooltip_imperial ||= if level
+          "#{date_label}: #{miles.round(1)} mi"
+        else
+          threshold = meters_to_miles(@competition.daily_distance_requirement).round
+          "#{date_label}: didn't ride #{threshold} miles"
+        end
       end
 
       def tooltip_metric

--- a/app/components/leaderboard/punchcard_user_row/component.rb
+++ b/app/components/leaderboard/punchcard_user_row/component.rb
@@ -18,15 +18,7 @@ module Leaderboard
       end
 
       def upcoming?(date_string)
-        return true if date_string > current_date_string
-        # Today defaults to "upcoming" (hidden) so we don't show a premature
-        # "no rides" dot on a day that isn't over — but render it as a punch
-        # once the user has activity on it.
-        date_string == current_date_string && distance_meters_on(date_string).zero?
-      end
-
-      def current_date_string
-        @current_date_string ||= @competition_user.current_date.to_s
+        @competition_user.upcoming?(date_string, distance_meters_on(date_string))
       end
 
       def days_count

--- a/app/models/competition_user.rb
+++ b/app/models/competition_user.rb
@@ -111,14 +111,8 @@ class CompetitionUser < ApplicationRecord
     @current_date ||= Time.current.in_time_zone(current_timezone).to_date
   end
 
-  def current_date_string
-    @current_date_string ||= current_date.to_s
-  end
-
   def upcoming?(date_string, distance_meters)
     return true if date_string > current_date_string
-    # Today stays "upcoming" until the user clears the daily requirement —
-    # otherwise an in-progress day with a short ride would render as an "x".
     date_string == current_date_string && distance_meters < competition.daily_distance_requirement
   end
 
@@ -157,6 +151,10 @@ class CompetitionUser < ApplicationRecord
   end
 
   private
+
+  def current_date_string
+    @current_date_string ||= current_date.to_s
+  end
 
   def dates_before_current_date
     return [] unless competition&.start_date

--- a/app/models/competition_user.rb
+++ b/app/models/competition_user.rb
@@ -111,6 +111,14 @@ class CompetitionUser < ApplicationRecord
     Time.current.in_time_zone(current_timezone).to_date
   end
 
+  def upcoming?(date_string, distance_meters)
+    current = current_date.to_s
+    return true if date_string > current
+    # Today stays "upcoming" until the user clears the daily requirement —
+    # otherwise an in-progress day with a short ride would render as an "x".
+    date_string == current && distance_meters < competition.daily_distance_requirement
+  end
+
   def latest_activity
     if association(:competition_activities_included).loaded?
       competition_activities_included.max_by { |a| a.start_at || Time.at(0) }

--- a/app/models/competition_user.rb
+++ b/app/models/competition_user.rb
@@ -108,15 +108,18 @@ class CompetitionUser < ApplicationRecord
   end
 
   def current_date
-    Time.current.in_time_zone(current_timezone).to_date
+    @current_date ||= Time.current.in_time_zone(current_timezone).to_date
+  end
+
+  def current_date_string
+    @current_date_string ||= current_date.to_s
   end
 
   def upcoming?(date_string, distance_meters)
-    current = current_date.to_s
-    return true if date_string > current
+    return true if date_string > current_date_string
     # Today stays "upcoming" until the user clears the daily requirement —
     # otherwise an in-progress day with a short ride would render as an "x".
-    date_string == current && distance_meters < competition.daily_distance_requirement
+    date_string == current_date_string && distance_meters < competition.daily_distance_requirement
   end
 
   def latest_activity

--- a/spec/components/leaderboard/punchcard_user_punch/component_spec.rb
+++ b/spec/components/leaderboard/punchcard_user_punch/component_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Leaderboard::PunchcardUserPunch::Component, type: :component do
       expect(cell.attr("data-century")).to be_nil
       expect(cell.attr("title")).to be_nil
       tooltip = rendered.css('[role="tooltip"]').first
-      expect(tooltip.text).to eq "May 1: didn't ride 2 miles"
+      expect(tooltip.css(".unit-imperial").text).to eq "May 1: didn't ride 2 miles"
+      expect(tooltip.css(".unit-metric").text).to eq "May 1: didn't ride 3 km"
       expect(cell.attr("aria-describedby")).to eq tooltip.attr("id")
     end
   end
@@ -36,7 +37,8 @@ RSpec.describe Leaderboard::PunchcardUserPunch::Component, type: :component do
       expect(cell.attr("data-century")).to be_nil
       expect(cell.attr("title")).to be_nil
       tooltip = rendered.css('[role="tooltip"]').first
-      expect(tooltip.text).to eq "May 1: 20.0 mi"
+      expect(tooltip.css(".unit-imperial").text).to eq "May 1: 20.0 mi"
+      expect(tooltip.css(".unit-metric").text).to eq "May 1: 32.2 km"
       expect(cell.attr("aria-describedby")).to eq tooltip.attr("id")
     end
   end

--- a/spec/components/leaderboard/punchcard_user_punch/component_spec.rb
+++ b/spec/components/leaderboard/punchcard_user_punch/component_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Leaderboard::PunchcardUserPunch::Component, type: :component do
   context "when distance is below the daily requirement" do
     let(:distance_meters) { 1_000 }
 
-    it "renders a cell with no data-l and 'no rides' tooltip" do
+    it "renders a cell with no data-l and a 'didn't ride' tooltip" do
       cell = rendered.css(".punchcard-cell").first
       expect(cell.attr("data-l")).to be_nil
       expect(cell.attr("data-century")).to be_nil
       expect(cell.attr("title")).to be_nil
       tooltip = rendered.css('[role="tooltip"]').first
-      expect(tooltip.text).to eq "May 1: no rides"
+      expect(tooltip.text).to eq "May 1: didn't ride 2 miles"
       expect(cell.attr("aria-describedby")).to eq tooltip.attr("id")
     end
   end

--- a/spec/components/leaderboard/punchcard_user_row/component_spec.rb
+++ b/spec/components/leaderboard/punchcard_user_row/component_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Leaderboard::PunchcardUserRow::Component, type: :component do
     expect(cells[1].attr("data-l")).to be_nil
     tooltip_id = cells[1].attr("aria-describedby")
     tooltip = rendered.css("##{tooltip_id}").first
-    expect(tooltip.text).to eq "May 2: no rides"
+    expect(tooltip.text).to eq "May 2: didn't ride 2 miles"
   end
 
   it "marks the century day" do
@@ -104,6 +104,16 @@ RSpec.describe Leaderboard::PunchcardUserRow::Component, type: :component do
         expect(today_cell.name).to eq "button"
         expect(today_cell["data-date"]).to eq "2026-04-16"
         expect(rendered.css(%([data-punch-activities-for="#{user.slug}-2026-04-16"])).count).to eq 1
+      end
+    end
+
+    context "when today's activity is below the daily distance requirement" do
+      let(:user_daily) { {"2026-04-16" => {distance_meters: 1_000, elevation_meters: 10}} }
+
+      it "keeps today as an upcoming plain span (no x) until the daily requirement is met" do
+        today_cell = rendered.css("div.h-7 > *")[15]
+        expect(today_cell.name).to eq "span"
+        expect(today_cell["class"]).to be_nil
       end
     end
 

--- a/spec/components/leaderboard/punchcard_user_row/component_spec.rb
+++ b/spec/components/leaderboard/punchcard_user_row/component_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe Leaderboard::PunchcardUserRow::Component, type: :component do
     expect(cells[1].attr("data-l")).to be_nil
     tooltip_id = cells[1].attr("aria-describedby")
     tooltip = rendered.css("##{tooltip_id}").first
-    expect(tooltip.text).to eq "May 2: didn't ride 2 miles"
+    expect(tooltip.css(".unit-imperial").text).to eq "May 2: didn't ride 2 miles"
+    expect(tooltip.css(".unit-metric").text).to eq "May 2: didn't ride 3 km"
   end
 
   it "marks the century day" do

--- a/spec/models/competition_user_spec.rb
+++ b/spec/models/competition_user_spec.rb
@@ -8,6 +8,30 @@ RSpec.describe CompetitionUser, type: :model do
     empty_score_hash.except(:ids).merge(periods: periods.map { |prd| prd.merge(empty_score_hash) })
   end
 
+  describe "upcoming?" do
+    let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2026-04-01")) }
+    let(:competition_user) { FactoryBot.create(:competition_user, competition:) }
+    before { allow(competition_user).to receive(:current_date).and_return(Date.parse("2026-04-16")) }
+
+    it "treats future dates as upcoming" do
+      expect(competition_user.upcoming?("2026-04-17", 0)).to be true
+      expect(competition_user.upcoming?("2026-04-17", 100_000)).to be true
+    end
+
+    it "treats past dates as not upcoming" do
+      expect(competition_user.upcoming?("2026-04-15", 0)).to be false
+      expect(competition_user.upcoming?("2026-04-15", 100_000)).to be false
+    end
+
+    it "treats today as upcoming until the daily distance requirement is met" do
+      threshold = competition.daily_distance_requirement
+      expect(competition_user.upcoming?("2026-04-16", 0)).to be true
+      expect(competition_user.upcoming?("2026-04-16", threshold - 1)).to be true
+      expect(competition_user.upcoming?("2026-04-16", threshold)).to be false
+      expect(competition_user.upcoming?("2026-04-16", threshold * 2)).to be false
+    end
+  end
+
   describe "included_activity_types" do
     let(:competition_user) { FactoryBot.create(:competition_user, included_activity_types:) }
     let(:included_activity_types) { nil }


### PR DESCRIPTION
Currently, a ride that doesn't clear the daily distance requirement flips today's punchcard cell to the red "x" state, even though the day isn't over. This keeps today as an upcoming plain span until the user clears `competition.daily_distance_requirement` — at which point it renders as a normal punch with a level.

- Move `upcoming?` from `Leaderboard::PunchcardUserRow::Component` to `CompetitionUser`, taking `(date_string, distance_meters)`. Future dates always upcoming; past dates never upcoming; today upcoming until `distance_meters >= competition.daily_distance_requirement`.
- `Leaderboard::PunchcardUserPunch::Component` tooltip for sub-threshold cells now reads "didn't ride 2 miles" (threshold derived from `daily_distance_requirement`) instead of "no rides".
