### PR TITLE
Show manual entry after competition ended in admin

### DIFF
--- a/app/components/leaderboard/rules/component.html.erb
+++ b/app/components/leaderboard/rules/component.html.erb
@@ -17,7 +17,7 @@
     <% if @competition.legacy? %>
       <li>Winner is the person who rides the most total miles</li>
       <li>
-        First place chooses what's for dinner, second and last place have to
+        1st place chooses what's for dinner, 2nd, 3rd and last place have to
         cook
       </li>
       <li>Person with the most elevation chooses desert</li>
@@ -32,7 +32,7 @@
       </li>
       <li>Ties are broken by total distance</li>
       <li>
-        First place chooses what's for dinner, second and last place have to
+        1st place chooses what's for dinner, 2nd, 3rd and last place have to
         cook
       </li>
       <li>Activities that count: <%= activity_types_display %></li>

--- a/app/components/leaderboard/rules/component.html.erb
+++ b/app/components/leaderboard/rules/component.html.erb
@@ -17,7 +17,7 @@
     <% if @competition.legacy? %>
       <li>Winner is the person who rides the most total miles</li>
       <li>
-        1st place chooses what's for dinner, 2nd, 3rd and last place have to
+        First place chooses what's for dinner, second and last place have to
         cook
       </li>
       <li>Person with the most elevation chooses desert</li>
@@ -32,7 +32,7 @@
       </li>
       <li>Ties are broken by total distance</li>
       <li>
-        1st place chooses what's for dinner, 2nd, 3rd and last place have to
+        First place chooses what's for dinner, second and last place have to
         cook
       </li>
       <li>Activities that count: <%= activity_types_display %></li>

--- a/app/models/competition_activity.rb
+++ b/app/models/competition_activity.rb
@@ -168,6 +168,10 @@ class CompetitionActivity < ApplicationRecord
     (created_at || Time.current) > competition_end_at_time
   end
 
+  def manual_entry_after_competition_ended?
+    manual_entry? && entered_after_competition_ended?
+  end
+
   def strava_distance_meters
     strava_data&.dig("distance")
   end
@@ -243,7 +247,7 @@ class CompetitionActivity < ApplicationRecord
   end
 
   def included_distance_meters
-    if manual_entry? && entered_after_competition_ended?
+    if manual_entry_after_competition_ended?
       0
     else
       strava_distance_meters

--- a/app/views/admin/competition_activities/index.html.erb
+++ b/app/views/admin/competition_activities/index.html.erb
@@ -42,8 +42,9 @@
     if ca.distance_meters
       safe_join([
         tag.span(safe_join([number_display(meters_to_miles(ca.distance_meters), round_to: 1), " mi"]), class: "unit-imperial"),
-        tag.span(safe_join([number_display(ca.distance_meters / 1000.0, round_to: 1), " km"]), class: "unit-metric hidden")
-      ])
+        tag.span(safe_join([number_display(ca.distance_meters / 1000.0, round_to: 1), " km"]), class: "unit-metric hidden"),
+        (tag.div("manual entry after competition ended", class: "less-strong") if ca.manual_entry_after_competition_ended?)
+      ].compact)
     end
   end
 

--- a/spec/models/competition_activity_spec.rb
+++ b/spec/models/competition_activity_spec.rb
@@ -284,6 +284,7 @@ RSpec.describe CompetitionActivity, type: :model do
       expect(competition_activity).to be_valid
       expect(competition_activity.manual_entry?).to be_truthy
       expect(competition_activity.entered_after_competition_ended?).to be_truthy
+      expect(competition_activity.manual_entry_after_competition_ended?).to be_truthy
       expect(competition_activity.strava_distance_meters).to eq 7000.7
       expect(competition_activity.distance_meters).to eq 0
       expect(competition_activity.activity_dates).to eq([Date.parse("2024-5-21")])
@@ -295,6 +296,7 @@ RSpec.describe CompetitionActivity, type: :model do
         expect(competition_activity).to be_valid
         expect(competition_activity.manual_entry?).to be_truthy
         expect(competition_activity.entered_after_competition_ended?).to be_falsey
+        expect(competition_activity.manual_entry_after_competition_ended?).to be_falsey
         expect(competition_activity.strava_distance_meters).to eq 7000.7
         expect(competition_activity.distance_meters).to eq 7000.7
         expect(competition_activity.activity_dates).to eq([Date.parse("2024-5-21")])


### PR DESCRIPTION
Manual activities entered after the competition ends already have their distance zeroed out (`included_distance_meters`), but admins had no way to see why. This surfaces that case in the admin activities table.

- Extract `manual_entry_after_competition_ended?` on `CompetitionActivity`, combining the existing `manual_entry?` and `entered_after_competition_ended?` predicates, and reuse it in `included_distance_meters`.
- Admin competition activities Distance column now shows a "manual entry after competition ended" note explaining the 0 distance.
