### PR TITLE
Add elevation victory to the leaderboard

### DIFF
--- a/app/components/leaderboard/punchcard_user_row/component.html.erb
+++ b/app/components/leaderboard/punchcard_user_row/component.html.erb
@@ -29,7 +29,12 @@
         <%= helpers.image_tag("strava_logo.svg", alt: "Strava", class: "w-3.5 h-3.5 block") %>
       </a>
 
-      <div class="flex items-center min-w-0">
+      <div
+        class="
+          flex items-center min-w-0 gap-1.5 lg:flex-col lg:items-start
+          lg:gap-0.5
+        "
+      >
         <button
           type="button"
           class="
@@ -46,6 +51,15 @@
         >
           <%= @competition_user.display_name %>
         </button>
+
+        <% if @competition_user.elevation_winner? %>
+          <span
+            class="text-[13px] leading-none whitespace-nowrap"
+            title="Elevation victory — most elevation, not in 1st place"
+          >
+            ⛰️🍰
+          </span>
+        <% end %>
       </div>
     </div>
 

--- a/app/components/leaderboard/punchcard_user_row/component.html.erb
+++ b/app/components/leaderboard/punchcard_user_row/component.html.erb
@@ -48,12 +48,9 @@
         </button>
 
         <% if @competition_user.elevation_winner? %>
-          <span
-            class="text-[13px] leading-none whitespace-nowrap"
-            title="Elevation victory — most elevation, not in 1st place"
-          >
-            ⛰️🍰
-          </span>
+          <%= render(UI::Tooltip::Component.new(text: "Elevation leader (person with the most elevation not in first place)")) do %>
+            <span class="text-[13px] leading-none whitespace-nowrap">⛰️🍰</span>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/components/leaderboard/punchcard_user_row/component.html.erb
+++ b/app/components/leaderboard/punchcard_user_row/component.html.erb
@@ -29,12 +29,7 @@
         <%= helpers.image_tag("strava_logo.svg", alt: "Strava", class: "w-3.5 h-3.5 block") %>
       </a>
 
-      <div
-        class="
-          flex items-center min-w-0 gap-1.5 lg:flex-col lg:items-start
-          lg:gap-0.5
-        "
-      >
+      <div class="flex items-center min-w-0 gap-1.5">
         <button
           type="button"
           class="

--- a/app/components/leaderboard/rules/component.html.erb
+++ b/app/components/leaderboard/rules/component.html.erb
@@ -17,7 +17,7 @@
     <% if @competition.legacy? %>
       <li>Winner is the person who rides the most total miles</li>
       <li>
-        First place chooses what's for dinner, second and last place have to
+        1st place chooses what's for dinner, 2nd, 3rd and last place have to
         cook
       </li>
       <li>Person with the most elevation chooses desert</li>
@@ -32,8 +32,11 @@
       </li>
       <li>Ties are broken by total distance</li>
       <li>
-        First place chooses what's for dinner, second and last place have to
+        1st place chooses what's for dinner, 2nd, 3rd and last place have to
         cook
+      </li>
+      <li title="⛰️🍰">
+        Person with the most elevation not in 1st place chooses desert
       </li>
       <li>Activities that count: <%= activity_types_display %></li>
       <li>

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -78,6 +78,15 @@ class Competition < ApplicationRecord
     @included_competition_user_ids_score_ordered ||= competition_users_included.score_ordered.pluck(:id)
   end
 
+  # The rider with the most elevation who isn't in 1st place wins elevation victory
+  def elevation_victor_id
+    return @elevation_victor_id if defined?(@elevation_victor_id)
+
+    @elevation_victor_id = competition_users_included.score_ordered.to_a.drop(1)
+      .select { |competition_user| competition_user.elevation_meters.positive? }
+      .max_by(&:elevation_meters)&.id
+  end
+
   def in_period?(passed_dates_or_times)
     return false if passed_dates_or_times.blank?
     activity_dates = dates_array_from(passed_dates_or_times)

--- a/app/models/competition_user.rb
+++ b/app/models/competition_user.rb
@@ -134,6 +134,11 @@ class CompetitionUser < ApplicationRecord
     competition.included_competition_user_ids_score_ordered.size
   end
 
+  def elevation_winner?
+    return false unless included_in_competition
+    id == competition.elevation_victor_id
+  end
+
   def everyday_rider?
     dates_before_current_date.all? { |date| activity_dates.include?(date.to_s) }
   end

--- a/spec/components/leaderboard/punchcard_body/component_spec.rb
+++ b/spec/components/leaderboard/punchcard_body/component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Leaderboard::PunchcardBody::Component, type: :component do
   let(:third_place) { competition_user_with(display_name: "Third Place", strava_id: "third", score: 2.0, elevation: 500.0) }
   let(:competition_users) { [first_place, second_place, third_place] }
   let(:rendered) { render_inline(described_class.new(competition:, competition_users:)) }
-  let(:badge) { rendered.css('span[title*="Elevation victory"]') }
+  let(:badge) { rendered.css('[aria-label*="Elevation leader"]') }
 
   it "marks the highest-elevation rider who isn't in 1st place" do
     expect(badge.count).to eq 1

--- a/spec/components/leaderboard/punchcard_body/component_spec.rb
+++ b/spec/components/leaderboard/punchcard_body/component_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Leaderboard::PunchcardBody::Component, type: :component do
+  let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2025-05-01")) }
+
+  def competition_user_with(display_name:, strava_id:, score:, elevation:)
+    user = FactoryBot.create(:user, display_name:, strava_id:)
+    cu = FactoryBot.create(:competition_user, user:, competition:)
+    cu.update_columns(score_data: {dates: [], distance: 1_000.0, elevation:}, score:)
+    cu.reload
+  end
+
+  # Passed in score order (rank 1 first), as the wrapper does via score_ordered
+  let(:first_place) { competition_user_with(display_name: "First Place", strava_id: "first", score: 9.0, elevation: 1_000.0) }
+  let(:second_place) { competition_user_with(display_name: "Second Place", strava_id: "second", score: 5.0, elevation: 800.0) }
+  let(:third_place) { competition_user_with(display_name: "Third Place", strava_id: "third", score: 2.0, elevation: 500.0) }
+  let(:competition_users) { [first_place, second_place, third_place] }
+  let(:rendered) { render_inline(described_class.new(competition:, competition_users:)) }
+  let(:badge) { rendered.css('span[title*="Elevation victory"]') }
+
+  it "marks the highest-elevation rider who isn't in 1st place" do
+    expect(badge.count).to eq 1
+    row = badge.first.ancestors.find { |node| node["class"]&.include?("border-b") }
+    expect(row.text).to include "Second Place"
+  end
+
+  context "when the 1st place rider has less elevation than another rider" do
+    let(:first_place) { competition_user_with(display_name: "First Place", strava_id: "first", score: 9.0, elevation: 100.0) }
+
+    it "still awards dessert to the highest-elevation non-1st rider" do
+      expect(badge.count).to eq 1
+      row = badge.first.ancestors.find { |node| node["class"]&.include?("border-b") }
+      expect(row.text).to include "Second Place"
+    end
+  end
+
+  context "when only the 1st place rider has elevation" do
+    let(:second_place) { competition_user_with(display_name: "Second Place", strava_id: "second", score: 5.0, elevation: 0.0) }
+    let(:third_place) { competition_user_with(display_name: "Third Place", strava_id: "third", score: 2.0, elevation: 0.0) }
+
+    it "awards dessert to no one" do
+      expect(badge.count).to eq 0
+    end
+  end
+end

--- a/spec/models/competition_user_spec.rb
+++ b/spec/models/competition_user_spec.rb
@@ -248,6 +248,30 @@ RSpec.describe CompetitionUser, type: :model do
     end
   end
 
+  describe "elevation_winner?" do
+    let(:competition) { FactoryBot.create(:competition, start_date: Date.parse("2024-05-01")) }
+    # competition_user2 is 1st place (more days), competition_user1 is 2nd
+    let!(:competition_user1) { FactoryBot.create(:competition_user, competition:, score_data: {dates: ["2024-05-01"], distance: 10_000, elevation: 500}) }
+    let!(:competition_user2) { FactoryBot.create(:competition_user, competition:, score_data: {dates: ["2024-05-01", "2024-05-02"], distance: 20_000, elevation: 900}) }
+    let!(:competition_user3) { FactoryBot.create(:competition_user, competition:, included_in_competition: false, score_data: {dates: ["2024-05-01"], distance: 50_000, elevation: 9_000}) }
+
+    it "is the highest-elevation included rider who isn't in 1st place" do
+      expect(competition.elevation_victor_id).to eq competition_user1.id
+      expect(competition_user1.elevation_winner?).to be_truthy
+      expect(competition_user2.elevation_winner?).to be_falsey # 1st place is excluded
+      expect(competition_user3.elevation_winner?).to be_falsey # not included, despite most elevation
+    end
+
+    context "when no non-1st rider has elevation" do
+      let!(:competition_user1) { FactoryBot.create(:competition_user, competition:, score_data: {dates: ["2024-05-01"], distance: 10_000, elevation: 0}) }
+
+      it "has no winner" do
+        expect(competition.elevation_victor_id).to be_nil
+        expect(competition_user1.elevation_winner?).to be_falsey
+      end
+    end
+  end
+
   describe "scoring" do
     let(:competition) { FactoryBot.create(:competition, start_date: Time.parse("2024-05-01")) }
     let(:competition_user1) { FactoryBot.create(:competition_user, competition:) }


### PR DESCRIPTION
Surfaces the "elevation victory" on the punchcard leaderboard — the rider with the most elevation who isn't in 1st place — so the dessert rule is visible at a glance.

- Add `Competition#elevation_victor_id` and `CompetitionUser#elevation_winner?` (most elevation among included riders, excluding 1st place).
- Show a ⛰️🍰 badge beneath the winner's name on desktop, to the right of it on mobile.
- Reword the dinner/dessert rules and add the "most elevation not in 1st place" rule line.
