### PR TITLE
Bump vulnerable gems: jwt, faraday, css_parser

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     annotaterb (4.14.0)
     ast (2.4.3)
+    auth-sanitizer (0.1.4)
+      version_gem (~> 1.1, >= 1.1.9)
     axe-core-api (4.11.1)
       dumb_delegator
       ostruct
@@ -135,7 +137,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    css_parser (2.0.0)
+    css_parser (2.2.0)
       addressable
     csv (3.3.5)
     date (3.5.1)
@@ -165,7 +167,7 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -234,7 +236,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.19.5)
-    jwt (2.8.1)
+    jwt (3.2.0)
       base64
     kamal (2.11.0)
       activesupport (>= 7.0)
@@ -326,13 +328,15 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oauth2 (2.0.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
+    oauth2 (2.0.20)
+      auth-sanitizer (~> 0.1, >= 0.1.3)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
+      snaky_hash (~> 2.0, >= 2.0.4)
+      version_gem (~> 1.1, >= 1.1.9)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -522,9 +526,9 @@ GEM
       redis-client (>= 0.26.0)
     sidekiq-failures (1.1.0)
       sidekiq (>= 4.0.0)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
+    snaky_hash (2.0.4)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     sshkit (1.25.0)
       base64
       logger
@@ -573,7 +577,7 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     vcr (6.2.0)
-    version_gem (1.1.4)
+    version_gem (1.1.9)
     view_component (4.10.0)
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)


### PR DESCRIPTION
Bumps three gems flagged by security advisories to their patched versions.

- **jwt** 2.8.1 → 3.2.0 — CVE-2026-45363 (High), empty-key HMAC bypass. The major bump required `oauth2` 2.0.9 → 2.0.20, which loosens its constraint to `jwt < 4.0`; `snaky_hash`, `version_gem`, and `auth-sanitizer` came along as transitive deps.
- **faraday** 2.14.1 → 2.14.2 — CVE-2026-33637 (Medium), protocol-relative URI host-scoping bypass.
- **css_parser** 2.0.0 → 2.2.0 — GHSA-ff6c-w6qf-7xqc (Medium), MITM injection of remote CSS (transitive via `lookbook`).

Lockfile-only change. jwt and css_parser are transitive; faraday is used directly in `strava_integration.rb`. Strava integration and OAuth login/webhook specs pass.
